### PR TITLE
feat: add webtor module for Tor integration

### DIFF
--- a/packages/webtor/README.md
+++ b/packages/webtor/README.md
@@ -1,0 +1,82 @@
+# @kohaku-eth/webtor
+
+Tor integration for browsers via WebAssembly. Make anonymous HTTP/HTTPS requests through Tor using Snowflake (WebRTC) and WebTunnel bridges—no server proxy needed.
+
+## Installation
+
+```bash
+pnpm add @kohaku-eth/webtor
+```
+
+## Usage
+
+```typescript
+import { TorClient, TorClientOptions, init } from "@kohaku-eth/webtor"
+
+// Initialize WASM module
+await init()
+
+// Create client with Snowflake WebRTC (most censorship-resistant)
+const client = await TorClient.create(TorClientOptions.snowflakeWebRtc())
+
+// Make anonymous requests through Tor
+const response = await client.fetch("https://check.torproject.org/")
+console.log(response.text())
+
+// Clean up
+await client.close()
+```
+
+## Transport Options
+
+```typescript
+// Snowflake via WebRTC (default, most censorship-resistant)
+TorClientOptions.snowflakeWebRtc()
+
+// Snowflake via direct WebSocket
+new TorClientOptions(snowflakeUrl)
+
+// WebTunnel (HTTPS, works through corporate proxies)
+TorClientOptions.webtunnel(url, fingerprint)
+```
+
+## Configuration
+
+```typescript
+const options = TorClientOptions.snowflakeWebRtc()
+  .withConnectionTimeout(30000)  // Connection timeout in ms
+  .withCircuitTimeout(60000)     // Circuit build timeout in ms
+```
+
+## API
+
+### `init()`
+Initialize the WASM module. Must be called before creating a client.
+
+### `TorClient.create(options)`
+Create a new Tor client with the specified options.
+
+### `client.fetch(url)`
+Make an anonymous HTTP request through Tor. Returns a `JsHttpResponse`.
+
+### `client.close()`
+Close the client and release resources.
+
+### `setDebugEnabled(enabled)`
+Enable/disable debug logging.
+
+### `setLogCallback(callback)`
+Set a callback function to receive log messages.
+
+## How It Works
+
+1. **Snowflake/WebTunnel** connects to a Tor bridge using WebRTC or HTTPS
+2. **Tor Protocol** builds a 3-hop circuit through the Tor network
+3. **Exit Relay** makes the actual HTTP request on your behalf
+4. Response travels back through the circuit, encrypted at each hop
+
+All traffic is anonymized—the destination sees the exit relay's IP, not yours.
+
+## License
+
+MIT

--- a/packages/webtor/package.json
+++ b/packages/webtor/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@kohaku-eth/webtor",
+  "version": "0.0.1",
+  "description": "Tor integration for browser via WebAssembly",
+  "type": "module",
+  "private": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "echo Building @kohaku-eth/webtor && tsup --config tsup.config.ts",
+    "dev": "tsup --config tsup.config.ts --watch",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "tor",
+    "wasm",
+    "privacy",
+    "anonymity"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "webtor-wasm": "file:../../../../webtor-rs/webtor-wasm/pkg"
+  },
+  "devDependencies": {
+    "@types/node": "^24.1.0",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/packages/webtor/src/index.ts
+++ b/packages/webtor/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @kohaku-eth/webtor
+ *
+ * Tor integration for browser via WebAssembly.
+ * Provides anonymous HTTP/HTTPS through Tor using Snowflake (WebRTC) and WebTunnel bridges.
+ */
+
+export {
+  TorClient,
+  TorClientOptions,
+  type JsHttpResponse,
+  type JsCircuitStatus,
+  init,
+  setDebugEnabled,
+  setLogCallback,
+} from "webtor-wasm"
+
+export type { InitInput, InitOutput, SyncInitInput } from "webtor-wasm"

--- a/packages/webtor/tsconfig.json
+++ b/packages/webtor/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/webtor/tsup.config.ts
+++ b/packages/webtor/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  external: ["webtor-wasm"],
+})


### PR DESCRIPTION
## Summary

Adds a new `@kohaku-eth/webtor` module that provides Tor integration for browsers via WebAssembly.

## Features

- Anonymous HTTP/HTTPS requests through Tor
- Snowflake (WebRTC) and WebTunnel bridge support
- No server proxy needed - runs entirely in the browser

## Usage

```typescript
import { TorClient, TorClientOptions, init } from "@kohaku-eth/webtor"

await init()
const client = await TorClient.create(TorClientOptions.snowflakeWebRtc())
const response = await client.fetch("https://check.torproject.org/")
console.log(response.text())
await client.close()
```

## Notes

- Currently uses a local file dependency to `webtor-wasm` (will be updated to npm package before merge)
- Based on [webtor-rs](https://github.com/voltrevo/webtor-rs) - a Rust Tor client for WebAssembly