### PR TITLE
Fix:Shielding Navigation Link

### DIFF
--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -37,7 +37,6 @@ export default defineConfig({
         },
         {
           text: 'Shielding',
-          link: '/railgun/shielding',
           collapsed: true,
           items: [
             {


### PR DESCRIPTION
Fixes and closes #18

The issue was caused by the parent "Shielding" item in the sidebar having the same `link` as its first child item. This confused the pagination logic. I removed the `link` property from the parent item in `docs/vocs.config.ts`, making it a pure collapsible category header.