### PR TITLE
remove reexport so MetroBundler does not require peerDependency

### DIFF
--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -1,4 +1,2 @@
 export * from './provider';
-export * as ethers from './ethers';
-export * as viem from './viem';
 export * from './tx';


### PR DESCRIPTION
fixes https://github.com/ethereum/kohaku/issues/47