### PR TITLE
docs: reframe /privacy around wallet data leaks

### DIFF
--- a/docs/pages/practices.mdx
+++ b/docs/pages/practices.mdx
@@ -1,5 +1,7 @@
 # Wallet Best Practices [What does the ultimate wallet look like?]
 
+This page focuses on mitigations for the privacy problems outlined in [Privacy in Ethereum](./privacy.mdx).
+
 ## Transaction Privacy
 
 By default ethereum transactions are transparent. This means anyone can see the amount, sender, recipient, and data within the transaction.
@@ -46,4 +48,3 @@ It lets you run a wrap an existing RPC and verify its results.
 ### Network Privacy
 
 The extremely privacy caution person, such as a journalist or privacy enthusiast, may want to add an extra layer of protection by routing their traffic through Tor.
-

--- a/docs/pages/privacy.mdx
+++ b/docs/pages/privacy.mdx
@@ -1,22 +1,41 @@
 # Privacy in Ethereum [Where are we at?]
 
+Privacy in Ethereum is often framed as an extra feature. In practice, many wallet privacy problems are data leaks.
+This page focuses on where those leaks happen. It is a diagnosis, not a list of mitigations.
+
+## Onchain Data Leaks
+
+Ethereum transactions are transparent by default. Amounts, senders, recipients, timing, and contract interactions are all visible onchain.
+
+That means wallet activity is easy to turn into an identity graph over time. Privacy tooling can reduce exposure, but the baseline is still public.
+
 ## One account to rule them all
 
-When you connect to a dApp today you are typically asked connect your wallet.
-This allows for anyone to see exactly what you have interacted with, when, and how.
+When you connect to a dApp today you are typically asked to connect the same wallet account you use everywhere else.
+That makes it easy to link one address to everything you do.
 
-Spreading your identity across multiple accounts, by for example having one address per dApp could already be a good start.
-Unfortunately not many wallets operate this way, most have a user experience designed for "a single active account at a time".
+One address can reveal where you trade, bridge, donate, vote, and experiment. Many wallets still optimize for a single active account, which makes identity reuse the default.
 
-## Default RPC
+## RPCs & Indexers
 
-A lot of wallets today use a default hardcoded RPC endpoint. Some even hitting the endpoint before the user has had a chance to setup their preferred configuration.
+A lot of wallets still use a default hardcoded RPC endpoint. Some even hit that endpoint before the user has had a chance to set up their preferred configuration.
 
-In addition to introducing centralization, this also introduced the risk of associating you with your wallet activity.
+This introduces centralization, but it also leaks intent. An RPC provider can see the balances you check, the contracts you inspect, and the chain activity you are interested in before anything is signed.
 
-## Token Discovery
+Token discovery can create a similar problem. Many wallets rely on a centralized indexer to monitor transfer events and enrich wallet state.
 
-Due to the nature of how token discovery works the majority of wallets today use a centralized indexer to monitor "all transfer events" on-chain.
+That convenience comes with a privacy cost. A third party can learn what assets a wallet receives and what activity the wallet is trying to surface.
 
-This allows for the discovery of new tokens right as theyre sent to your wallet.
-Although this is a nice-to-have it does have privacy drawbacks.
+## Network Metadata
+
+Even when the requested data is minimal, network metadata can still leak. IP address, timing, and request patterns can help associate wallet activity with a person, device, or location.
+
+Wallet privacy is not only about what gets requested. It is also about where requests come from and how those requests can be correlated over time.
+
+## UI-side Leakage
+
+Some leaks happen before a request even leaves the interface. Fingerprintable settings, installed capabilities, and other client-side behavior can make one wallet instance easier to distinguish from another.
+
+This is a broader wallet ecosystem problem, and not every protocol library can solve it on its own. It is still part of the privacy model.
+
+For mitigations and wallet design choices, see [Wallet Best Practices](./practices.mdx).


### PR DESCRIPTION
## Why

`/privacy` currently covers only part of the wallet data leak model. This PR tightens that page around where leaks happen, while keeping the scope intentionally narrow and avoiding a broader wallet safety rewrite.

## What

- reframe `/privacy` as a short diagnosis page for wallet data leaks
- add explicit sections for onchain leaks, account reuse, RPC/indexer leaks, network metadata, and UI-side leakage
- add a minimal bridge from `/practices` back to `/privacy` so the two pages read as diagnosis vs mitigations

## Out of scope

- transaction safety topics such as malicious tx proposals, wrong destination address, or wrong token address
- account security topics such as control over the account
- navigation changes, `getting-started` edits, or new documentation pages

## Validation

- docs build passes with `npx -y node@24 ./node_modules/vocs/_lib/cli/index.js build` from `docs/`