### PR TITLE
feat: update colibri-stateless to v1.1.22 

### DIFF
--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -72,7 +72,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@a16z/helios": ">=0.11",
-    "@corpus-core/colibri-stateless": ">=1.1.0 <2",
+    "@corpus-core/colibri-stateless": ">=1.1.22 <2",
     "ethers": "^6.13.1"
   },
   "peerDependenciesMeta": {

--- a/packages/provider/src/colibri/colibri-stateless.d.ts
+++ b/packages/provider/src/colibri/colibri-stateless.d.ts
@@ -1,13 +1,54 @@
 /* eslint-disable import/no-default-export */
 declare module '@corpus-core/colibri-stateless' {
-    export interface RequestArguments {
-        method: string;
-        params?: unknown[] | Record<string, unknown>;
+    export class ProviderRpcError extends Error {
+        public code: number;
+        public data?: unknown;
+        constructor(code: number, message: string, data?: unknown);
+        static createError(error: unknown, args?: RequestArguments): ProviderRpcError;
     }
+
+    export interface ColibriClient {
+        rpc(method: string, params: unknown[], method_type?: MethodType): Promise<unknown>;
+        getMethodSupport(method: string, args?: unknown[]): Promise<MethodType>;
+    }
+
+    export type FetchRpc = (
+        urls: string[],
+        payload: unknown,
+        as_proof: boolean,
+        fetchFn?: typeof globalThis.fetch,
+    ) => Promise<unknown>;
+
+    export type ProofStrategy = (
+        client: ColibriClient,
+        req: RequestArguments,
+        config: Config,
+        fetch_rpc: FetchRpc,
+    ) => Promise<unknown>;
+
+    export type WarningHandler = (req: RequestArguments, message: string) => Promise<unknown>;
+
+    export interface RequestArguments {
+        readonly method: string;
+        readonly params?: readonly unknown[] | object;
+    }
+
+    export interface ProviderConnectInfo {
+        readonly chainId: string;
+    }
+
+    export interface ProviderMessage {
+        readonly type: string;
+        readonly data: unknown;
+    }
+
+    export type PrivacyMode = 'none' | 'basic';
 
     export interface Cache {
         cacheable(req: DataRequest): boolean;
-        get(req: DataRequest): Uint8Array | undefined;
+        get(
+            req: DataRequest,
+        ): Uint8Array | undefined | null | Promise<Uint8Array | undefined | null>;
         set(req: DataRequest, data: Uint8Array): void;
     }
 
@@ -19,7 +60,7 @@ declare module '@corpus-core/colibri-stateless' {
         trusted_checkpoint?: string;
         verify?: (method: string, args: unknown[]) => boolean;
         pollingInterval?: number;
-        proofStrategy?: unknown;
+        proofStrategy?: ProofStrategy;
         verifyTransactions?: boolean;
     }
 
@@ -28,6 +69,8 @@ declare module '@corpus-core/colibri-stateless' {
         on(event: string, callback: (data: unknown) => void): this;
         removeListener(event: string, callback: (data: unknown) => void): this;
     }
+
+    export type ProverMode = 'local' | 'remote' | 'hybrid' | 'proxy' | 'light_client';
 
     export interface DataRequest {
         method: string;
@@ -40,22 +83,34 @@ declare module '@corpus-core/colibri-stateless' {
         req_ptr: number;
     }
 
-    export interface C4Config extends ChainConfig {
+    export interface Config extends ChainConfig {
         chainId: number | string;
         checkpoint_witness_keys?: string;
         cache?: Cache;
         debug?: boolean;
         include_code?: boolean;
+        use_accesslist?: boolean;
+        privacy_mode?: PrivacyMode;
         zk_proof?: boolean;
+        prover_mode?: ProverMode;
         chains: {
             [chainId: number]: ChainConfig;
         };
         fallback_provider?: EIP1193Client;
-        warningHandler?: (req: RequestArguments, message: string) => Promise<unknown>;
+        warningHandler: WarningHandler;
+        onTransfer?: (size: number, req: DataRequest) => void;
+        fetch?: typeof globalThis.fetch;
+    }
+
+    export enum MethodType {
+        PROOFABLE = 1,
+        UNPROOFABLE = 2,
+        NOT_SUPPORTED = 3,
+        LOCAL = 4,
     }
 
     class Colibri {
-        constructor(config?: Partial<C4Config>);
+        constructor(config?: Partial<Config>);
         request(args: RequestArguments): Promise<unknown>;
     }
 

--- a/packages/provider/src/colibri/index.ts
+++ b/packages/provider/src/colibri/index.ts
@@ -29,7 +29,7 @@ async function importColibri(): Promise<ColibriConstructor> {
 export const colibri = async (config: ColibriConfig): Promise<EthereumProvider<Colibri>> => {
     const createColibri = await importColibri();
     const client = new createColibri({
-        verifyTransactions: true,
+        verifyTransactions: config.fallback_provider ? true : false,
         zk_proof: true,
         ...config,
     });

--- a/packages/provider/src/colibri/index.ts
+++ b/packages/provider/src/colibri/index.ts
@@ -1,15 +1,13 @@
 import { raw } from '../raw';
 import type { EthereumProvider } from '../provider';
-import type { C4Config, default as Colibri } from '@corpus-core/colibri-stateless';
+import type { Config, default as Colibri } from '@corpus-core/colibri-stateless';
 import { Provider } from 'ox/Provider';
 
-export type ColibriConfig = Partial<C4Config>;
+export type ColibriConfig = Partial<Config>;
 
 type ColibriConstructor = new (config?: ColibriConfig) => Colibri;
 
 async function importColibri(): Promise<ColibriConstructor> {
-    // Colibri-Stateless exports the client as default export (ESM):
-    // `export default class C4Client { ... }`
     const mod = (await import('@corpus-core/colibri-stateless')) as unknown as {
         default?: ColibriConstructor;
     };
@@ -30,7 +28,11 @@ async function importColibri(): Promise<ColibriConstructor> {
   */
 export const colibri = async (config: ColibriConfig): Promise<EthereumProvider<Colibri>> => {
     const createColibri = await importColibri();
-    const client = new createColibri(config);
+    const client = new createColibri({
+        verifyTransactions: true,
+        zk_proof: true,
+        ...config,
+    });
 
     return {
         ...raw(client as unknown as Provider),


### PR DESCRIPTION
- **Bump minimum `@corpus-core/colibri-stateless`** peer dependency from `>=1.1.0` to `>=1.1.22`
- **Sync type declarations** (`colibri-stateless.d.ts`) with the upstream [types.ts](https://github.com/corpus-core/colibri-stateless/blob/dev/bindings/emscripten/src/types.ts) — adds `ProviderRpcError`, `ColibriClient`, `ProofStrategy`, `WarningHandler`, `PrivacyMode`, `ProverMode`, `MethodType`, and renames `C4Config` → `Config`
