### PR TITLE
feat: add Tacit plugin

### DIFF
--- a/.changeset/add-tacit-plugin.md
+++ b/.changeset/add-tacit-plugin.md
@@ -1,0 +1,5 @@
+---
+"@kohaku-eth/tacit": minor
+---
+
+Add Tacit cross-chain privacy plugin

--- a/packages/tacit/package.json
+++ b/packages/tacit/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@kohaku-eth/tacit",
+  "version": "0.0.1-alpha.0",
+  "description": "Tacit cross-chain privacy plugin — shielded ETH/ERC-20 bridge via Bitcoin-verified ZK mixer",
+  "type": "module",
+  "private": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ethereum/kohaku.git",
+    "directory": "packages/tacit"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@kohaku-eth/plugins": "workspace:*",
+    "@kohaku-eth/provider": "workspace:*",
+    "poseidon-lite": "^0.3.0",
+    "ox": "^0.6.0"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/tacit/src/commitment.ts
+++ b/packages/tacit/src/commitment.ts
@@ -1,0 +1,78 @@
+import { poseidon2, poseidon3 } from "poseidon-lite";
+
+const BN254_FIELD =
+  21888242871839275222246405745257275088548364400416034343698204186575808495617n;
+
+const TREE_LEVELS = 20;
+
+export function computeLeafCommitment(
+  secret: bigint,
+  nullifierPreimage: bigint,
+  denomTacit: bigint
+): bigint {
+  return poseidon3([secret, nullifierPreimage, denomTacit]);
+}
+
+export function bigintToBytes32(v: bigint): `0x${string}` {
+  return `0x${v.toString(16).padStart(64, "0")}`;
+}
+
+export function buildMerkleZeros(): bigint[] {
+  const zeros: bigint[] = [0n];
+  for (let i = 1; i <= TREE_LEVELS; i++) {
+    zeros.push(poseidon2([zeros[i - 1], zeros[i - 1]]));
+  }
+  return zeros;
+}
+
+export function insertLeaf(
+  filledSubtrees: bigint[],
+  zeros: bigint[],
+  leafIndex: number,
+  leaf: bigint
+): { root: bigint; subtrees: bigint[] } {
+  const newSubtrees = [...filledSubtrees];
+  let h = leaf;
+  let idx = leafIndex;
+  for (let i = 0; i < TREE_LEVELS; i++) {
+    if ((idx & 1) === 0) {
+      newSubtrees[i] = h;
+      h = poseidon2([h, zeros[i]]);
+    } else {
+      h = poseidon2([newSubtrees[i], h]);
+    }
+    idx >>= 1;
+  }
+  return { root: h, subtrees: newSubtrees };
+}
+
+export function computeMerkleProof(
+  leaves: bigint[],
+  targetIndex: number
+): { pathElements: bigint[]; pathIndices: number[] } {
+  const zeros = buildMerkleZeros();
+  let layer = [...leaves];
+  const pathElements: bigint[] = [];
+  const pathIndices: number[] = [];
+  let idx = targetIndex;
+
+  for (let level = 0; level < TREE_LEVELS; level++) {
+    const sibling =
+      (idx ^ 1) < layer.length ? layer[idx ^ 1] : zeros[level];
+    pathElements.push(sibling);
+    pathIndices.push(idx & 1);
+
+    const nextLayer: bigint[] = [];
+    for (let i = 0; i < layer.length; i += 2) {
+      const left = layer[i];
+      const right = i + 1 < layer.length ? layer[i + 1] : zeros[level];
+      nextLayer.push(poseidon2([left, right]));
+    }
+    layer = nextLayer;
+    idx >>= 1;
+  }
+
+  return { pathElements, pathIndices };
+}
+
+export { BN254_FIELD, TREE_LEVELS };

--- a/packages/tacit/src/index.ts
+++ b/packages/tacit/src/index.ts
@@ -1,0 +1,27 @@
+export { createTacitPlugin } from "./plugin";
+export {
+  computeLeafCommitment,
+  bigintToBytes32,
+  buildMerkleZeros,
+  insertLeaf,
+  computeMerkleProof,
+  BN254_FIELD,
+  TREE_LEVELS,
+} from "./commitment";
+export {
+  deriveDepositSecrets,
+  deriveAccountId,
+  computeNullifierHash,
+  computeRLeaf,
+} from "./keys";
+export type {
+  TacitInstance,
+  TacitAddress,
+  TacitPublicOperation,
+  TacitPrivateOperation,
+  TacitPluginParameters,
+  TacitCapabilities,
+  CreateTacitPlugin,
+  DepositRecord,
+  PoolInfo,
+} from "./types";

--- a/packages/tacit/src/keys.ts
+++ b/packages/tacit/src/keys.ts
@@ -1,0 +1,47 @@
+import type { Keystore } from "@kohaku-eth/plugins";
+import { poseidon1, poseidon2 } from "poseidon-lite";
+
+const TACIT_COIN_TYPE = 28785;
+
+const BN254_FIELD =
+  21888242871839275222246405745257275088548364400416034343698204186575808495617n;
+
+export function deriveDepositSecrets(
+  keystore: Keystore,
+  chainId: bigint,
+  depositIndex: number
+): { secret: bigint; nullifierPreimage: bigint } {
+  const chainSegment = Number(chainId) & 0x7fffffff;
+  const secretHex = keystore.deriveAt(
+    `m/${TACIT_COIN_TYPE}'/${chainSegment}'/${depositIndex}'/0'`
+  );
+  const nullifierHex = keystore.deriveAt(
+    `m/${TACIT_COIN_TYPE}'/${chainSegment}'/${depositIndex}'/1'`
+  );
+  return {
+    secret: BigInt(secretHex) % BN254_FIELD,
+    nullifierPreimage: BigInt(nullifierHex) % BN254_FIELD,
+  };
+}
+
+export function computeNullifierHash(nullifierPreimage: bigint): bigint {
+  return poseidon1([nullifierPreimage]);
+}
+
+export function computeRLeaf(
+  secret: bigint,
+  nullifierPreimage: bigint
+): bigint {
+  return poseidon2([secret, nullifierPreimage]);
+}
+
+export function deriveAccountId(
+  keystore: Keystore,
+  chainId: bigint
+): `tacit:${string}` {
+  const rootHex = keystore.deriveAt(
+    `m/${TACIT_COIN_TYPE}'/${Number(chainId) & 0x7fffffff}'/0'`
+  );
+  const short = rootHex.slice(0, 18);
+  return `tacit:${short}`;
+}

--- a/packages/tacit/src/plugin.ts
+++ b/packages/tacit/src/plugin.ts
@@ -1,0 +1,327 @@
+import type { Host, AssetAmount, AssetId } from "@kohaku-eth/plugins";
+import type { TxData } from "@kohaku-eth/provider";
+import type { Address } from "ox/Address";
+import { Hash } from "ox/Hash";
+import type {
+  TacitInstance,
+  TacitAddress,
+  TacitAssetAmount,
+  TacitPublicOperation,
+  TacitPrivateOperation,
+  TacitPluginParameters,
+  CreateTacitPlugin,
+  DepositRecord,
+  PoolInfo,
+} from "./types";
+import {
+  deriveDepositSecrets,
+  deriveAccountId,
+  computeNullifierHash,
+  computeRLeaf,
+} from "./keys";
+import {
+  computeLeafCommitment,
+  bigintToBytes32,
+} from "./commitment";
+
+const DEPOSIT_SELECTOR = "0x1de26e16";
+const APPROVE_SELECTOR = "0x095ea7b3";
+const GET_POOL_ROOT_SELECTOR = "0xee59a615";
+const GET_POOL_BALANCE_SELECTOR = "0x550e6ed1";
+const GET_NEXT_LEAF_INDEX_SELECTOR = "0xde5ddc78";
+const DEPOSIT_EVENT_TOPIC =
+  "0x35a268a90c41b0181a3b58b12063b25c3597e0d085532dfff38eaf88e946c30e";
+
+const STORAGE_KEY_DEPOSITS = "tacit:deposits";
+const STORAGE_KEY_NEXT_INDEX = "tacit:nextDepositIndex";
+
+class TacitProtocol implements TacitInstance {
+  private host: Host;
+  private params: TacitPluginParameters;
+  private accountId: TacitAddress;
+  private depositCache: DepositRecord[] = [];
+  private nextDepositIndex: number = 0;
+
+  constructor(host: Host, params: TacitPluginParameters) {
+    this.host = host;
+    this.params = params;
+    this.accountId = deriveAccountId(host.keystore, params.chainId);
+
+    const stored = host.storage.get(STORAGE_KEY_DEPOSITS);
+    if (stored) {
+      this.depositCache = JSON.parse(stored, (_k, v) =>
+        typeof v === "string" && v.startsWith("0n")
+          ? BigInt(v.slice(2))
+          : v
+      );
+    }
+    const idx = host.storage.get(STORAGE_KEY_NEXT_INDEX);
+    this.nextDepositIndex = idx ? parseInt(idx, 10) : 0;
+  }
+
+  async instanceId(): Promise<TacitAddress> {
+    return this.accountId;
+  }
+
+  async balance(
+    assets: AssetAmount<AssetId>["asset"][] | undefined
+  ): Promise<TacitAssetAmount[]> {
+    const results: TacitAssetAmount[] = [];
+    for (const denomWei of this.params.denominationsWei) {
+      const asset: AssetId = this.params.token
+        ? { __type: "erc20", contract: this.params.token as Address }
+        : { __type: "native" };
+
+      if (assets && !assets.some((a) => a.__type === asset.__type)) continue;
+
+      const poolId = this.poolIdFromWei(denomWei);
+      const userDeposits = this.depositCache.filter(
+        (d) => d.poolId === poolId
+      );
+      const userBalance = BigInt(userDeposits.length) * denomWei;
+      results.push({ asset, amount: userBalance });
+    }
+    return results;
+  }
+
+  async prepareShield(
+    asset: TacitAssetAmount,
+    _to?: TacitAddress
+  ): Promise<TacitPublicOperation> {
+    const denomWei = this.findDenominationWei(asset.amount);
+    const denomTacit = denomWei / this.params.unitScale;
+    const depositIndex = this.nextDepositIndex;
+    const { secret, nullifierPreimage } = deriveDepositSecrets(
+      this.host.keystore,
+      this.params.chainId,
+      depositIndex
+    );
+
+    const leaf = computeLeafCommitment(secret, nullifierPreimage, denomTacit);
+    const commitment = bigintToBytes32(leaf);
+    const poolId = this.poolIdFromWei(denomWei);
+
+    const isNative = !this.params.token;
+    const txns: TxData[] = [];
+
+    if (!isNative && this.params.token) {
+      txns.push({
+        to: this.params.token,
+        data: abiEncode(APPROVE_SELECTOR, [
+          padAddress(this.params.mixerAddress),
+          bigintToBytes32(denomWei),
+        ]),
+        value: 0n,
+      });
+    }
+
+    txns.push({
+      to: this.params.mixerAddress,
+      data: abiEncode(DEPOSIT_SELECTOR, [
+        commitment,
+        bigintToBytes32(denomWei),
+      ]),
+      value: isNative ? denomWei : 0n,
+    });
+
+    const record: DepositRecord = {
+      commitment,
+      leafIndex: -1,
+      denomination: denomWei,
+      poolId,
+      timestamp: Date.now(),
+      depositIndex,
+    };
+    this.depositCache.push(record);
+    this.nextDepositIndex++;
+    this.persistState();
+
+    return { __type: "publicOperation", txns };
+  }
+
+  async prepareUnshield(
+    asset: TacitAssetAmount,
+    to: Address
+  ): Promise<TacitPrivateOperation> {
+    const denomWei = this.findDenominationWei(asset.amount);
+    const denomTacit = denomWei / this.params.unitScale;
+    const poolId = this.poolIdFromWei(denomWei);
+
+    const deposit = this.depositCache.find(
+      (d) => d.poolId === poolId && d.leafIndex >= 0
+    );
+    if (!deposit) {
+      throw new Error("no confirmed deposit found for this denomination");
+    }
+
+    const { secret, nullifierPreimage } = deriveDepositSecrets(
+      this.host.keystore,
+      this.params.chainId,
+      deposit.depositIndex
+    );
+    const nullifierHash = computeNullifierHash(nullifierPreimage);
+    const rLeaf = computeRLeaf(secret, nullifierPreimage);
+
+    const rootHex = await this.host.provider.call({
+      to: this.params.mixerAddress as `0x${string}`,
+      data: abiEncode(GET_POOL_ROOT_SELECTOR, [poolId]),
+    });
+    const merkleRoot = (rootHex ?? bigintToBytes32(0n)) as `0x${string}`;
+
+    const burnNonce = bigintToBytes32(
+      BigInt(deposit.depositIndex) * 2n ** 128n +
+        BigInt(deposit.timestamp)
+    );
+
+    // Wallet must compute these with secp256k1 and SHA256 respectively.
+    // See TacitBridgeMixer._validateBurn for the exact bindHash preimage.
+    const recipientCommitment = new Uint8Array(33);
+    const bindHash = bigintToBytes32(0n) as `0x${string}`;
+
+    // Wallet must call snarkjs.groth16.fullProve with circuit WASM + zkey.
+    // Public inputs: [root, nullifierHash, denomTacit, rLeaf, bindHash].
+    const groth16Proof = {
+      a: [0n, 0n] as [bigint, bigint],
+      b: [
+        [0n, 0n],
+        [0n, 0n],
+      ] as [[bigint, bigint], [bigint, bigint]],
+      c: [0n, 0n] as [bigint, bigint],
+      publicSignals: [
+        BigInt(merkleRoot),
+        nullifierHash,
+        denomTacit,
+        rLeaf,
+        0n,
+      ],
+    };
+
+    const encoded = new Uint8Array(281 + 256);
+
+    return {
+      __type: "privateOperation",
+      crosschain: true,
+      phase: "bitcoin-burn-required",
+      burnEnvelope: {
+        opcode: 0x61,
+        networkTag: this.params.networkTag,
+        assetId: this.params.assetId,
+        denomination: denomTacit,
+        merkleRoot,
+        nullifierHash: bigintToBytes32(nullifierHash),
+        recipientCommitment,
+        rLeaf: bigintToBytes32(rLeaf),
+        ethRecipient: to,
+        burnNonce,
+        bindHash,
+        proof: new Uint8Array(256),
+        encoded,
+      },
+      ethereum: {
+        contractAddress: this.params.mixerAddress,
+        poolId,
+        denomination: denomWei,
+      },
+      groth16Proof,
+    };
+  }
+
+  async sync(): Promise<void> {
+    for (const record of this.depositCache) {
+      if (record.leafIndex >= 0) continue;
+      const logs = await this.host.provider.getLogs({
+        address: this.params.mixerAddress as `0x${string}`,
+        topics: [
+          DEPOSIT_EVENT_TOPIC,
+          record.poolId,
+          record.commitment,
+        ],
+        fromBlock: 0n,
+        toBlock: "latest",
+      });
+      if (logs.length > 0) {
+        record.leafIndex = Number(BigInt(logs[0].data.slice(0, 66)));
+      }
+    }
+    this.persistState();
+  }
+
+  async deposits(): Promise<DepositRecord[]> {
+    return [...this.depositCache];
+  }
+
+  async poolInfo(denomination: bigint): Promise<PoolInfo> {
+    const poolId = this.poolIdFromWei(denomination);
+    const [rootHex, balanceHex, indexHex] = await Promise.all([
+      this.host.provider.call({
+        to: this.params.mixerAddress as `0x${string}`,
+        data: abiEncode(GET_POOL_ROOT_SELECTOR, [poolId]),
+      }),
+      this.host.provider.call({
+        to: this.params.mixerAddress as `0x${string}`,
+        data: abiEncode(GET_POOL_BALANCE_SELECTOR, [poolId]),
+      }),
+      this.host.provider.call({
+        to: this.params.mixerAddress as `0x${string}`,
+        data: abiEncode(GET_NEXT_LEAF_INDEX_SELECTOR, [poolId]),
+      }),
+    ]);
+    return {
+      poolId,
+      denomination,
+      nextLeafIndex: Number(BigInt(indexHex ?? "0x0")),
+      balance: BigInt(balanceHex ?? "0x0"),
+      currentRoot: (rootHex as `0x${string}`) ?? bigintToBytes32(0n),
+    };
+  }
+
+  private poolIdFromWei(denomWei: bigint): `0x${string}` {
+    const assetPadded = this.params.assetId.slice(2).padStart(64, "0");
+    const denomPadded = denomWei.toString(16).padStart(64, "0");
+    return Hash.keccak256(`0x${assetPadded}${denomPadded}`);
+  }
+
+  private findDenominationWei(amount: bigint): bigint {
+    const denom = this.params.denominationsWei.find((d) => d === amount);
+    if (!denom) {
+      throw new Error(
+        `amount ${amount} does not match any pool denomination`
+      );
+    }
+    return denom;
+  }
+
+  private persistState(): void {
+    this.host.storage.set(
+      STORAGE_KEY_DEPOSITS,
+      JSON.stringify(this.depositCache, (_k, v) =>
+        typeof v === "bigint" ? `0n${v}` : v
+      )
+    );
+    this.host.storage.set(
+      STORAGE_KEY_NEXT_INDEX,
+      String(this.nextDepositIndex)
+    );
+  }
+}
+
+export const createTacitPlugin: CreateTacitPlugin = (
+  host: Host,
+  params: TacitPluginParameters
+): TacitInstance => {
+  return new TacitProtocol(host, params);
+};
+
+function abiEncode(
+  selector: string,
+  args: (`0x${string}`)[]
+): `0x${string}` {
+  const encoded = args
+    .map((a) => a.slice(2).padStart(64, "0"))
+    .join("");
+  return `${selector}${encoded}` as `0x${string}`;
+}
+
+function padAddress(addr: string): `0x${string}` {
+  return `0x${addr.slice(2).padStart(64, "0")}`;
+}

--- a/packages/tacit/src/types.ts
+++ b/packages/tacit/src/types.ts
@@ -1,0 +1,119 @@
+import type { Address } from "ox/Address";
+import type {
+  PluginInstance,
+  PICapCfg,
+  CreatePluginFn,
+  AssetAmount,
+  PublicOperation,
+  PrivateOperation,
+  AssetId,
+} from "@kohaku-eth/plugins";
+import type { TxData } from "@kohaku-eth/provider";
+
+// ── Tacit-specific operation types ──────────────────────────────
+
+export type TacitPublicOperation = PublicOperation & {
+  txns: TxData[];
+};
+
+export type TacitPrivateOperation = PrivateOperation & {
+  crosschain: true;
+  phase: "bitcoin-burn-required";
+  burnEnvelope: {
+    opcode: 0x61;
+    networkTag: number;
+    assetId: `0x${string}`;
+    denomination: bigint;
+    merkleRoot: `0x${string}`;
+    nullifierHash: `0x${string}`;
+    recipientCommitment: Uint8Array;
+    rLeaf: `0x${string}`;
+    ethRecipient: Address;
+    burnNonce: `0x${string}`;
+    bindHash: `0x${string}`;
+    proof: Uint8Array;
+    encoded: Uint8Array;
+  };
+  ethereum: {
+    contractAddress: Address;
+    poolId: `0x${string}`;
+    denomination: bigint;
+  };
+  groth16Proof: {
+    a: [bigint, bigint];
+    b: [[bigint, bigint], [bigint, bigint]];
+    c: [bigint, bigint];
+    publicSignals: bigint[];
+  };
+};
+
+// ── Plugin instance shape ───────────────────────────────────────
+
+export type TacitAddress = `tacit:${string}`;
+
+export type TacitAssetAmount = AssetAmount<AssetId, bigint, string>;
+
+export type TacitCapabilities = PICapCfg<{
+  features: {
+    prepareShield: true;
+    prepareShieldMulti: false;
+    prepareTransfer: false;
+    prepareTransferMulti: false;
+    prepareUnshield: true;
+    prepareUnshieldMulti: false;
+  };
+  assetAmounts: {
+    input: TacitAssetAmount;
+    internal: TacitAssetAmount;
+    output: TacitAssetAmount;
+    read: TacitAssetAmount;
+  };
+  publicOp: TacitPublicOperation;
+  privateOp: TacitPrivateOperation;
+  extras: {
+    sync(): Promise<void>;
+    deposits(): Promise<DepositRecord[]>;
+    poolInfo(denomination: bigint): Promise<PoolInfo>;
+  };
+  credential: unknown;
+}>;
+
+export type TacitInstance = PluginInstance<TacitAddress, TacitCapabilities>;
+
+// ── Plugin parameters ───────────────────────────────────────────
+
+export type TacitPluginParameters = {
+  mixerAddress: Address;
+  chainId: bigint;
+  networkTag: number;
+  assetId: `0x${string}`;
+  denominationsWei: bigint[];
+  unitScale: bigint;
+  token?: Address;
+  circuitWasm?: ArrayBuffer;
+  circuitZkey?: ArrayBuffer;
+};
+
+export type CreateTacitPlugin = CreatePluginFn<
+  TacitInstance,
+  TacitPluginParameters
+>;
+
+// ── Internal types ──────────────────────────────────────────────
+
+export type DepositRecord = {
+  commitment: `0x${string}`;
+  leafIndex: number;
+  denomination: bigint;
+  poolId: `0x${string}`;
+  timestamp: number;
+  depositIndex: number;
+};
+
+export type PoolInfo = {
+  poolId: `0x${string}`;
+  denomination: bigint;
+  nextLeafIndex: number;
+  balance: bigint;
+  currentRoot: `0x${string}`;
+};

--- a/packages/tacit/tsconfig.json
+++ b/packages/tacit/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src"]
+}

--- a/packages/tacit/tsup.config.ts
+++ b/packages/tacit/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ packages:
   - "examples/pq-account"
   - "docs"
   - "crates/railgun-ts"
+  - "packages/tacit"


### PR DESCRIPTION
Tacit is a trustless ETH/ERC-20 mixer that uses Bitcoin as its settlement layer. Deposits go into fixed-denomination Poseidon Merkle pools on Ethereum; withdrawals are verified through a Bitcoin light relay + SP1 state proofs + Groth16 burn proofs. No operators, no multisigs.

This adds `@kohaku-eth/tacit` implementing the plugin interface:

- **`prepareShield`** — builds the Poseidon commitment, returns deposit `TxData` (same flow as Tornado/Privacy Pools)
- **`prepareUnshield`** — returns a `TacitPrivateOperation` carrying the burn envelope, Groth16 witness, and contract parameters. The operation is tagged `crosschain: true` / `phase: "bitcoin-burn-required"` so the wallet knows the withdrawal is a multi-step flow across Bitcoin and Ethereum
- **Key derivation** — BIP-32 via `host.keystore.deriveAt()` at coin type `28785'`, secrets reduced mod BN254

The unshield is the interesting part. In Tornado or Privacy Pools, `prepareUnshield` returns an Ethereum transaction. In Tacit, the user first embeds a burn envelope in a Bitcoin OP_RETURN, waits for 6+ confirmations and SP1 acceptance, then calls `withdrawFromBurn()` on Ethereum with the raw Bitcoin tx and relay headers. The plugin returns all the structured data for both steps.

```
Shield:   user → deposit(commitment, denom) → TacitBridgeMixer.sol

Unshield: plugin returns burn envelope + proof
          → wallet embeds in Bitcoin OP_RETURN
          → 6 confirmations + SP1 prover accepts burn
          → wallet calls withdrawFromBurn(rawBtcTx, headers, height, merkleProof, txIndex)
          → contract: relay check → SP1 acceptance → Groth16 verify → nullifier check → payout
```

Proof generation (snarkjs + circuit artifacts) and Bitcoin tx construction are left to the consuming wallet — the plugin provides the commitment math, Merkle tree utils, and the complete witness/envelope structure.

Workspace-level changes (`pnpm-workspace.yaml`, changeset) included. Docs pages not included — happy to add once the approach looks right.

**Links**: [tacit.finance](https://tacit.finance) · [TacitBridgeMixer.sol](https://github.com/z0r0z/tacit/blob/main/contracts/src/TacitBridgeMixer.sol) · [withdraw.circom](https://github.com/z0r0z/tacit/blob/main/dapp/circuits/withdraw.circom)