### PR TITLE
fix: add missing demo/simple.ts referenced by package.json in tornado-cash

### DIFF
--- a/.changeset/add-tornado-cash-demo.md
+++ b/.changeset/add-tornado-cash-demo.md
@@ -1,0 +1,9 @@
+---
+"@kohaku-eth/tornado-cash": patch
+---
+
+Add minimal `demo/simple.ts` script referenced by the `pnpm demo` package script.
+The script derives a deposit commitment from a mnemonic and encodes the
+corresponding deposit transaction for the 0.1 ETH mainnet pool (no network
+calls, no broadcast). Drop `rootDir` from tsconfig so `pnpm check` covers the
+`demo` directory already listed in `include`.

--- a/packages/tornado-cash/demo/simple.ts
+++ b/packages/tornado-cash/demo/simple.ts
@@ -1,0 +1,99 @@
+// Minimal Tornado Cash classic example: derive a deposit commitment from a
+// mnemonic and produce a deposit transaction for a fixed-denomination pool.
+// No network calls and nothing is broadcast — this script just exposes the
+// math/encoding pipeline so the deterministic value flow is easy to inspect.
+//
+// Run:
+//   pnpm -r build   # once, from repo root, so workspace packages link
+//   pnpm demo       # from this package directory
+
+import { HDNodeWallet, Mnemonic } from "ethers";
+import type { Keystore } from "@kohaku-eth/plugins";
+
+import { SecretManager } from "../src/account/keys";
+import { prepareNativeShield } from "../src/account/tx/shield";
+
+// ---------------------------------------------------------------------------
+// 1. Build a BIP32 keystore from a mnemonic.
+//
+//    SecretManager derives nullifier/salt deterministically from this
+//    keystore (path m/29795'/1'/account'/secretType'/depositIndex'), so
+//    backing up the mnemonic is enough to recover every deposit — no
+//    note file to store, unlike the original Tornado Cash UI.
+// ---------------------------------------------------------------------------
+const MNEMONIC =
+  "test test test test test test test test test test test junk"; // demo only — never reuse on mainnet
+const masterNode = HDNodeWallet.fromSeed(
+  Mnemonic.fromPhrase(MNEMONIC).computeSeed(),
+);
+const keystore: Keystore = {
+  deriveAt: (path) =>
+    masterNode.derivePath(path).privateKey as `0x${string}`,
+};
+
+const secretManager = await SecretManager({ host: { keystore }, accountIndex: 0 });
+
+// ---------------------------------------------------------------------------
+// 2. Derive secrets for one deposit slot.
+//
+//    `chainId` and `poolAddress` are folded into the secrets so that the
+//    same mnemonic produces independent secrets per pool deployment.
+//    Classic pools have a fixed denomination per instance; this is the
+//    canonical mainnet 0.1 ETH pool.
+// ---------------------------------------------------------------------------
+const CHAIN_ID = 1n; // Ethereum mainnet
+const POOL_ADDRESS = "0x12D66f87A04A9E220743712cE6d9bB1B5616B8Fc"; // 0.1 ETH instance
+const POOL_DENOMINATION = 100_000_000_000_000_000n; // 0.1 ETH
+const DEPOSIT_INDEX = 0;
+
+const secrets = await secretManager.getDepositSecrets({
+  chainId: CHAIN_ID,
+  poolAddress: BigInt(POOL_ADDRESS),
+  depositIndex: DEPOSIT_INDEX,
+});
+
+console.log(
+  `--- Derived secrets (chainId=${CHAIN_ID}, depositIndex=${DEPOSIT_INDEX}) ---`,
+);
+console.log("nullifier      :", secrets.nullifier);
+console.log("salt           :", secrets.salt);
+console.log(
+  "commitment     :",
+  secrets.commitment,
+  " <-- this is what lands on-chain",
+);
+console.log(
+  "nullifierHash  :",
+  secrets.nullifierHash,
+  " <-- revealed on withdraw to prevent double-spend",
+);
+
+// ---------------------------------------------------------------------------
+// 3. Encode the deposit transaction.
+//
+//    Calldata carries only `commitment` — the nullifier/salt never leave
+//    the keystore. The pool's fixed denomination goes into `value`.
+// ---------------------------------------------------------------------------
+const tx = prepareNativeShield({
+  commitment: secrets.commitment,
+  poolAddress: POOL_ADDRESS,
+  poolDenomination: POOL_DENOMINATION,
+});
+
+console.log("\n--- Deposit transaction (not broadcast) ---");
+console.log("to    :", tx.to);
+console.log("value :", tx.value, "wei");
+console.log("data  :", tx.data);
+
+// To actually broadcast on mainnet, plug in a viem WalletClient. For example:
+//
+//   import { createWalletClient, http } from "viem";
+//   import { privateKeyToAccount } from "viem/accounts";
+//   import { mainnet } from "viem/chains";
+//
+//   const wallet = createWalletClient({
+//     account: privateKeyToAccount("0x..."),
+//     chain: mainnet,
+//     transport: http(),
+//   });
+//   await wallet.sendTransaction({ to: tx.to, data: tx.data, value: tx.value });

--- a/packages/tornado-cash/tsconfig.json
+++ b/packages/tornado-cash/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
     "verbatimModuleSyntax": false,
     "paths": {
       "#worker-loader": ["./src/plugin/worker-loader.browser.js"],


### PR DESCRIPTION
## Summary
`packages/tornado-cash/package.json` references `demo/simple.ts` via the `pnpm demo` script, but the file (and the `demo/` directory) was never committed, so running `pnpm demo` currently fails with `ERR_MODULE_NOT_FOUND`. This adds a minimal offline demo mirroring the privacy-pools one from #190: derive deposit secrets from a mnemonic using `SecretManager`, then encode the deposit transaction for the mainnet 0.1 ETH pool using `prepareNativeShield`. No network calls, nothing broadcast.

## Reproduction (before this PR)
```
$ pnpm demo
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'.../packages/tornado-cash/demo/simple.ts'
```

## Output (after this PR)
```
--- Derived secrets (chainId=1, depositIndex=0) ---
nullifier      : 319372339522625217636528292638642678073984470207469630839918762199047134883n
salt           : 298374834881409605829236087865468702515110191377301405644553261128144389657n
commitment     : 1230943522148548613947702297761422466173192296627548658007063121761483578405n  <-- this is what lands on-chain
nullifierHash  : 4241814385335272619720589440953131367486552390439110068392522074475978414847n  <-- revealed on withdraw to prevent double-spend

--- Deposit transaction (not broadcast) ---
to    : 0x12D66f87A04A9E220743712cE6d9bB1B5616B8Fc
value : 100000000000000000n wei
data  : 0xb214faa502b8b078d5c40644f7a021b036a365ee9b146e14e2530e2dc9fc716b01cf5c25
```

The calldata embeds only the 32-byte `commitment` (selector `0xb214faa5` = `deposit(bytes32)`); nullifier/salt never leave the keystore, and the pool's fixed denomination goes into `value`.

## Notes
- `tsconfig.json`'s `include` already lists `demo`, but `rootDir: "./src"` made tsc reject any file there (TS6059), which would break `pnpm check` the moment the demo exists — so this drops `rootDir`. Build output is unaffected (`build` uses tsup; tsc is only used for the no-emit `check`).

## Test plan
- [x] `pnpm demo` from `packages/tornado-cash/` produces the output above
- [x] `pnpm check` (tsc --noEmit, now also covers `demo/`)
- [x] `pnpm build` unaffected
- [x] `npx eslint demo/simple.ts` clean