### PR TITLE
[TC] Fix worker loading when processing multiple withdrawals

### DIFF
--- a/packages/tornado-cash/package.json
+++ b/packages/tornado-cash/package.json
@@ -93,7 +93,7 @@
     "comlink": "^4.4.2",
     "fixed-merkle-tree": "^0.7.3",
     "maci-crypto": "2.5.0",
-    "micro-zk-proofs": "0.3.0",
+    "micro-zk-proofs": "0.3.1",
     "ox": "^0.12.0",
     "snarkjs": "git+https://github.com/tornadocash/snarkjs.git#869181cfaf7526fe8972073d31655493a04326d5",
     "viem": "^2.51.3",

--- a/packages/tornado-cash/src/state/thunks/paymasterWithdrawThunk.ts
+++ b/packages/tornado-cash/src/state/thunks/paymasterWithdrawThunk.ts
@@ -12,6 +12,7 @@ import { verifyRootsThunk } from "./verifyRootsThunk";
 import { WithdrawalProofsThunkParams, withdrawalsProofThunk } from "./withdrawalsProofThunk";
 import { getWithdrawableDepositsSelector } from "../selectors/withdrawals.selector";
 import { IGenericPaymasterWithdrawalPayload, SignedDelegation } from "../../relayer/interfaces/paymaster-client.interface";
+import { TornadoProveOutput } from "../../utils/tornado-prover";
 
 export interface PaymasterWithdrawThunkParams extends Omit<WithdrawalProofsThunkParams, 'deposit' | 'fee' | 'relayerAddress'> {
   dataService: IDataService;
@@ -88,22 +89,29 @@ export const paymasterWithdrawThunk = createAsyncThunk<
   // The relayer address in the proof is the paymaster — it receives the fee
   const relayerAddress = BigInt(paymasterAddress) as Address;
 
-  const proofOutputs = await Promise.all(deposits.map(async (deposit) => {
-    const withdrawResultAction = await dispatch(
-      withdrawalsProofThunk({
-        ...rest,
-        deposit,
-        relayerAddress,
-        fee,
-      }),
-    );
+  const getProofOutputs = async () => {
+    const results: (TornadoProveOutput & {poolAddress: bigint})[] = [];
 
-    return {
-      ...unwrapResult(withdrawResultAction),
-      poolAddress: deposit.pool
-    };
-  }));
+    for (const deposit of deposits) {
+      const withdrawResultAction = await dispatch(
+        withdrawalsProofThunk({
+          ...rest,
+          deposit,
+          relayerAddress,
+          fee,
+        }),
+      );
+  
+      results.push({
+        ...unwrapResult(withdrawResultAction),
+        poolAddress: deposit.pool
+      });
+    }
 
+    return results;
+  }
+
+  const proofOutputs = await getProofOutputs();
 
   // Compute delegation only for deterministic mode — random is deferred to broadcast.
   // Each deposit gets its own signer derived from its deposit index.

--- a/packages/tornado-cash/src/state/thunks/withdrawThunk.ts
+++ b/packages/tornado-cash/src/state/thunks/withdrawThunk.ts
@@ -64,57 +64,65 @@ export const withdrawThunk = createAsyncThunk<
     const gasPrice = await dataService.getGasPrice();
     const networkFee = gasPrice * WITHDRAW_GAS;
 
-    return Promise.all(deposits.map(async (deposit) => {
-      const pool = pools.get(deposit.pool);
+    const getWithdrawalsProofs = async () => {
+      const results: IWithdrawalPayload[] = [];
 
-      if (!pool) {
-        throw new Error('Pool not found');
+      for (const deposit of deposits) {
+        const pool = pools.get(deposit.pool);
+
+        if (!pool) {
+          throw new Error('Pool not found');
+        }
+
+        const serviceFee = pool.denomination * BigInt(Math.round(tornadoServiceFee * 100)) / 10_000n;
+    
+        let fee: bigint;
+    
+        if (poolInfo.isERC20) {
+          const asset = assetSelector(state).get(assetAddress as Address);
+    
+          if (!asset) throw new Error(`Asset info not found for ${assetAddress}`);
+    
+          const tokenPriceStr =
+            ethPrices[asset.symbol.toLowerCase()] ??
+            ethPrices[asset.symbol.toUpperCase()] ??
+            ethPrices[asset.symbol];
+    
+          if (!tokenPriceStr) throw new Error(`No ETH price found for token ${asset.symbol}`);
+    
+          const tokenPrice = BigInt(tokenPriceStr);
+    
+          if (tokenPrice === 0n) throw new Error(`Token price is zero for ${asset.symbol}`);
+    
+          const ethFeeInToken = networkFee * (10n ** BigInt(asset.decimals)) / tokenPrice;
+    
+          fee = ethFeeInToken + serviceFee;
+        } else {
+          fee = networkFee + serviceFee;
+        }
+    
+        // Generate proofs for each deposit
+        const withdrawResultAction = await dispatch(
+          withdrawalsProofThunk({
+              ...rest,
+              deposit,
+              relayerAddress: BigInt(rewardAccount) as Address,
+              fee,
+          }),
+        );
+
+        const proof = unwrapResult(withdrawResultAction);
+
+        results.push({
+          mode: 'relayer' as const,
+          proof,
+          poolAddress: deposit.pool,
+          relayerUrl,
+        });
       }
+      
+      return results;
+    }
 
-      const serviceFee = pool.denomination * BigInt(Math.round(tornadoServiceFee * 100)) / 10_000n;
-  
-      let fee: bigint;
-  
-      if (poolInfo.isERC20) {
-        const asset = assetSelector(state).get(assetAddress as Address);
-  
-        if (!asset) throw new Error(`Asset info not found for ${assetAddress}`);
-  
-        const tokenPriceStr =
-          ethPrices[asset.symbol.toLowerCase()] ??
-          ethPrices[asset.symbol.toUpperCase()] ??
-          ethPrices[asset.symbol];
-  
-        if (!tokenPriceStr) throw new Error(`No ETH price found for token ${asset.symbol}`);
-  
-        const tokenPrice = BigInt(tokenPriceStr);
-  
-        if (tokenPrice === 0n) throw new Error(`Token price is zero for ${asset.symbol}`);
-  
-        const ethFeeInToken = networkFee * (10n ** BigInt(asset.decimals)) / tokenPrice;
-  
-        fee = ethFeeInToken + serviceFee;
-      } else {
-        fee = networkFee + serviceFee;
-      }
-  
-      // Generate proofs for each deposit
-      const withdrawResultAction = await dispatch(
-        withdrawalsProofThunk({
-            ...rest,
-            deposit,
-            relayerAddress: BigInt(rewardAccount) as Address,
-            fee,
-        }),
-      );
-
-      const proof = unwrapResult(withdrawResultAction);
-
-      return {
-        mode: 'relayer' as const,
-        proof,
-        poolAddress: deposit.pool,
-        relayerUrl,
-      }
-    }));
+    return getWithdrawalsProofs();
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,8 +389,8 @@ importers:
         specifier: 2.5.0
         version: 2.5.0
       micro-zk-proofs:
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.1
+        version: 0.3.1
       ox:
         specifier: ^0.12.0
         version: 0.12.4(typescript@5.9.3)(zod@4.4.3)
@@ -6369,8 +6369,8 @@ packages:
   micro-wrkr@0.2.0:
     resolution: {integrity: sha512-yZdhhfWMwMTAFQc/5cRUtCGURF/HplgP15WmItE8La0f/Dn1t9ckZh4vW6LvV3AMdSRYAfKGdbXyvhxIKy1Xxw==}
 
-  micro-zk-proofs@0.3.0:
-    resolution: {integrity: sha512-ueAtCjOuyniumaKTQ3CJslFPZnaQUR9Y3chTr0Cxfenmz1ti/e1+5jOYFunaOOeYUMEVkKMtqNKJhiW5wa1BpQ==}
+  micro-zk-proofs@0.3.1:
+    resolution: {integrity: sha512-Vjn2jY+TvJHL44byIvMuMzduAm9lsA+uZunzchZ46AdAgvK4X4SU3uiaCToX2I1DbMQXrpGBIXyJqmvYzl7pVg==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -8004,6 +8004,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -15544,7 +15545,7 @@ snapshots:
 
   micro-wrkr@0.2.0: {}
 
-  micro-zk-proofs@0.3.0:
+  micro-zk-proofs@0.3.1:
     dependencies:
       '@noble/ciphers': 2.2.0
       '@noble/curves': 2.2.0


### PR DESCRIPTION
As the name states, when generating multiple withdrawals at the same time, we were instantiating a worker instance (times the number of cores of the machine) per withdrawal, instead of reutilizing the existing instance.
This also updates the micro-zk-proofs library with fixes for the browser.