### PR TITLE
feat(railgun): add MaybeSend bounds to RailgunSigner for thread-safety

### DIFF
--- a/crates/railgun/src/account/signer.rs
+++ b/crates/railgun/src/account/signer.rs
@@ -8,8 +8,10 @@ use crate::{
     crypto::keys::{SpendingKey, SpendingSignature, ViewingKey},
 };
 
+use common::MaybeSend;
+
 /// A railgun signer which can sign transactions and provide the associated 0xzk address.
-pub trait RailgunSigner {
+pub trait RailgunSigner: MaybeSend {
     fn chain_id(&self) -> ChainId;
     fn viewing_key(&self) -> ViewingKey;
     fn spending_key(&self) -> SpendingKey;

--- a/crates/railgun/src/transact/mod.rs
+++ b/crates/railgun/src/transact/mod.rs
@@ -1,6 +1,7 @@
-pub(crate) mod proved_transaction;
+pub mod proved_transaction;
 mod shield_builder;
 mod transaction_builder;
 
+pub use proved_transaction::{ProvedTx, ProvedOperation};
 pub use shield_builder::{ShieldBuilder, ShieldError};
 pub use transaction_builder::{TransactionBuilder, TransactionBuilderError};


### PR DESCRIPTION
 This PR adds the `common::MaybeSend` constraint to the `RailgunSigner` trait and exports
  the `ProvedTx` / `ProvedOperation` structs. This allows the SDK to compile under Tokio on
  native desktop platforms (supporting Dioxus/Tauri wallets like Vaughan) without requiring
  unsafe newtype wrappers.