### PR TITLE
feat(provider): allow @corpus-core/colibri-stateless v2 in peer range

### DIFF
--- a/.changeset/colibri-v2-peer-range.md
+++ b/.changeset/colibri-v2-peer-range.md
@@ -1,0 +1,9 @@
+---
+"@kohaku-eth/provider": patch
+---
+
+Widen the `@corpus-core/colibri-stateless` peer dependency range to `>=1.1.22 <3` so Colibri v2 is accepted.
+
+Colibri v2 switches to the 64-bit SP1 v6 zk-proofs, which are a breaking change. The old SP1 v5 zk-proofs are still generated in parallel for some time, but adopting v2 ensures we can shut down the v5 provers as soon as possible.
+
+The public API used by the provider (the default `Colibri` constructor and `Config`) is unchanged between v1 and v2.

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -72,7 +72,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@a16z/helios": ">=0.11",
-    "@corpus-core/colibri-stateless": ">=1.1.22 <2",
+    "@corpus-core/colibri-stateless": ">=1.1.22 <3",
     "ethers": "^6.13.1"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
- Widen the `@corpus-core/colibri-stateless` peer dependency range in `@kohaku-eth/provider` from `>=1.1.22 <2` to `>=1.1.22 <3` so Colibri v2 is accepted.
- Colibri v2 switches to the 64-bit SP1 v6 zk-proofs, which are a **breaking change** versus SP1 v5. The old SP1 v5 zk-proofs are still generated in parallel for some time, but adopting v2 ensures we can shut down the v5 provers as soon as possible.
- The public API used by the provider (the default `Colibri` constructor and `Config`) is unchanged between v1 and v2.
- Adds a `patch` changeset.
