### PR TITLE
feat: reworking delegators to support arbitrary signers

### DIFF
--- a/packages/tornado-cash/src/account/delegation.interface.ts
+++ b/packages/tornado-cash/src/account/delegation.interface.ts
@@ -1,0 +1,32 @@
+import type { LocalAccount } from 'viem/accounts';
+
+/**
+ * The subset of a signing account the paymaster withdrawal flow needs from the
+ * batch delegator.
+ *
+ * In the EIP-7702 Simple7702 design the delegator *is* the userOp sender, so it
+ * must sign both the 7702 authorization and the userOp hash — not merely the
+ * authorization. A viem `LocalAccount` satisfies this structurally (so
+ * `privateKeyToAccount` adapts in one line), and a host-supplied hardware/remote
+ * signer can satisfy it too. This is the injection seam consumed by
+ * `buildSignedTornadoUserOp`.
+ */
+export type DelegatorAccount = Pick<LocalAccount, 'address' | 'signTypedData'> & {
+  // `signAuthorization` is optional on `LocalAccount`; the delegator must have it.
+  signAuthorization: NonNullable<LocalAccount['signAuthorization']>;
+};
+
+/**
+ * How the batch delegator for a tail-call paymaster withdrawal is produced.
+ * Only honored when `tailCalls` are present (see `paymasterWithdrawThunk`).
+ *
+ * - `deterministic` (default): recoverable. With `path`, the delegator is a
+ *   classical wallet-path address; without `path`, an ephemeral address keyed by
+ *   the batch's first deposit.
+ * - `random`: a throwaway, unrecoverable EOA — an explicit opt-out of
+ *   recoverability. Never the default, because in the tail-call path the
+ *   delegator holds the withdrawn funds.
+ */
+export type DelegationConfig =
+  | { mode: 'deterministic'; path?: string }
+  | { mode: 'random' };

--- a/packages/tornado-cash/src/account/keys.ts
+++ b/packages/tornado-cash/src/account/keys.ts
@@ -41,6 +41,13 @@ type DeriveSecretsParams = BaseDeriveSecretParams & {
 export interface ISecretManager {
   getDepositSecrets: (params: DeriveDepositSecretParams) => Promise<Secret>;
   deriveEphemeralSigner: (params: DeriveDepositSecretParams) => Promise<`0x${string}`>;
+  /**
+   * Derives a delegator key from a classical wallet BIP-32 `path`, WITHOUT the
+   * `coalesceSecret` privacy transform, so it resolves to a recoverable,
+   * classical Ethereum address. Used for the tail-call batch delegator when the
+   * integrator supplies a wallet path (see `paymasterWithdrawThunk`).
+   */
+  deriveDelegatorSigner: (params: { path: string }) => Promise<`0x${string}`>;
 }
 
 export interface SecretManagerParams {
@@ -115,9 +122,16 @@ export async function SecretManager({
     return `0x${coalesced.toString(16).padStart(64, '0')}` as `0x${string}`;
   };
 
+  // No coalesce: a classical wallet path yields a real private key whose address
+  // is recoverable by the user's wallet, so a stuck delegator can be swept.
+  const deriveDelegatorSigner = async ({ path }: { path: string }) => {
+    return Promise.resolve(keystore.deriveAt(path)) as Promise<`0x${string}`>;
+  };
+
   return {
     getDepositSecrets: (params) => deriveSecrets(params),
     deriveEphemeralSigner,
+    deriveDelegatorSigner,
   };
 }
 

--- a/packages/tornado-cash/src/interfaces/user-ops.interface.ts
+++ b/packages/tornado-cash/src/interfaces/user-ops.interface.ts
@@ -1,6 +1,7 @@
 import { TxData } from "@kohaku-eth/provider";
 import { Address } from "ox/Address";
 import { Hex } from "ox/Hex";
+import { DelegatorAccount } from "../account/delegation.interface";
 
 export interface SerializedAuth {
     address: Address;
@@ -43,7 +44,12 @@ export interface UserOpGasLimits {
 }
 
 export interface BuildSignedTornadoUserOpParams {
-  privateKey: Hex;
+  /**
+   * The account that becomes the userOp sender: it signs both the EIP-7702
+   * authorization and the userOp hash. Injection seam — a viem `LocalAccount`
+   * (via `privateKeyToAccount`) or a host-supplied hardware/remote signer.
+   */
+  signer: DelegatorAccount;
   chainId: number;
   paymasterAddress: Address;
   paymasterData: Hex;

--- a/packages/tornado-cash/src/paymaster/utils.ts
+++ b/packages/tornado-cash/src/paymaster/utils.ts
@@ -100,7 +100,7 @@ export function ephemeralSenderAddress(privateKey: Hex): Address {
  * required — gas limits and fees are supplied by the caller.
  */
 export async function buildSignedTornadoUserOp({
-  privateKey,
+  signer,
   chainId,
   paymasterAddress,
   paymasterData,
@@ -111,7 +111,7 @@ export async function buildSignedTornadoUserOp({
   nonce = 0n,
 }: BuildSignedTornadoUserOpParams): Promise<SerializedUserOperation> {
 
-  const owner = privateKeyToAccount(privateKey);
+  const owner = signer;
 
   const calls = await tailCalls(owner.address);
   let callData: Hex = '0x';

--- a/packages/tornado-cash/src/plugin/interfaces/protocol-params.interface.ts
+++ b/packages/tornado-cash/src/plugin/interfaces/protocol-params.interface.ts
@@ -13,10 +13,9 @@ import { PublicRootState } from '../../state/store';
 import { IRelayerFeeConfig } from '../../state/slices/relayersSlice';
 import { IGenericPaymasterWithdrawalPayload } from '../../relayer/interfaces/paymaster-client.interface';
 import { Address } from '../../interfaces/types.interface';
+import type { DelegationConfig } from '../../account/delegation.interface';
 
-export type DelegationConfig =
-  | { mode: 'deterministic'; path?: string }
-  | { mode: 'random' };
+export type { DelegationConfig };
 
 type StringAddress = `0x${string}`
 export interface IPaymasterConfig {

--- a/packages/tornado-cash/src/state/thunks/paymasterWithdrawThunk.ts
+++ b/packages/tornado-cash/src/state/thunks/paymasterWithdrawThunk.ts
@@ -6,10 +6,11 @@ import { ISecretManager } from "../../account/keys";
 import { IDataService } from "../../data/interfaces/data.service.interface";
 import { Address } from "../../interfaces/types.interface";
 import { encodePaymasterData, encodeTornadoAdapterData } from "@privacy-paymasters/sdk";
-import { generatePrivateKey } from "viem/accounts";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
 import { computeMinimumViableFee, reasonableGasUnits } from "../../paymaster/fee";
-import { buildSignedTornadoUserOp, createPaymasterBundlerClient, ephemeralSenderAddress, getUserOperationGasPrice } from "../../paymaster/utils";
+import { buildSignedTornadoUserOp, createPaymasterBundlerClient, getUserOperationGasPrice } from "../../paymaster/utils";
+import { DelegatorAccount } from "../../account/delegation.interface";
 import { DelegationConfig, IChainsPaymastersConfig, IWithdrawalPayload } from "../../plugin/interfaces/protocol-params.interface";
 import { instanceRegistryInfoSelector, poolsSelector } from "../selectors/slices.selectors";
 import { RootState } from "../store";
@@ -19,6 +20,16 @@ import { getWithdrawableDepositsSelector } from "../selectors/withdrawals.select
 import { TornadoProveOutput } from "../../utils/tornado-prover";
 import { IGenericPaymasterWithdrawalPayload } from "../../relayer/interfaces/paymaster-client.interface";
 import { SerializedUserOperation } from "../../interfaces/user-ops.interface";
+
+// A BIP-32 path: `m` followed by one or more `/index` segments, each optionally
+// hardened with a trailing apostrophe (e.g. m/44'/60'/0'/0/0).
+const BIP32_PATH = /^m(\/\d+'?)+$/;
+
+function assertValidDelegatorPath(path: string): void {
+  if (!BIP32_PATH.test(path)) {
+    throw new Error(`Invalid delegation path "${path}": expected a BIP-32 path like m/44'/60'/0'/0/0`);
+  }
+}
 
 export interface PaymasterWithdrawThunkParams extends Omit<WithdrawalProofsThunkParams, 'deposit' | 'fee' | 'relayerAddress'> {
   dataService: IDataService;
@@ -98,11 +109,33 @@ export const paymasterWithdrawThunk = createAsyncThunk<
   const bigintChainId = await dataService.getChainId();
   const { recipient: originalRecipient, ...restWithoutRecipient } = rest;
 
-  // When tailCalls are present, all deposits in this batch share one ephemeral
-  // key so every withdrawal lands in the same EOA. The last userOp then runs
-  // tailCalls against the full accumulated balance. Deterministic derivation is
-  // skipped in this path — reproducibility of a shared batch key is meaningless.
-  const sharedPrivateKey = tailCalls ? generatePrivateKey() : null;
+  const ephemeralSigner = async (deposit: (typeof deposits)[number]): Promise<DelegatorAccount> =>
+    privateKeyToAccount(await secretManager.deriveEphemeralSigner({
+      depositIndex: deposit.index,
+      chainId: bigintChainId,
+      poolAddress: deposit.pool,
+    }));
+
+  // Tail calls: every deposit shares one delegator so all withdrawals land in the
+  // same EOA (the recipient), and the last userOp spends the accumulated balance.
+  // That EOA holds the funds, so it is recoverable by default (`random` opts out).
+  const resolveBatchDelegator = async (): Promise<DelegatorAccount> => {
+    if (delegation?.mode === 'random') return privateKeyToAccount(generatePrivateKey());
+    if (delegation?.mode === 'deterministic' && delegation.path) {
+      assertValidDelegatorPath(delegation.path);
+      return privateKeyToAccount(await secretManager.deriveDelegatorSigner({ path: delegation.path }));
+    }
+    return ephemeralSigner(deposits[0]!);
+  };
+
+  // No tail calls: a per-deposit sender that never holds funds (the withdrawal
+  // goes to the user's `recipient`), so a random default is fine.
+  const resolveIndependentSigner = (deposit: (typeof deposits)[number]): Promise<DelegatorAccount> =>
+    delegation?.mode === 'deterministic'
+      ? ephemeralSigner(deposit)
+      : Promise.resolve(privateKeyToAccount(generatePrivateKey()));
+
+  const sharedDelegator = tailCalls ? await resolveBatchDelegator() : null;
 
   const proofOutputs: (TornadoProveOutput & { poolAddress: bigint })[] = [];
   const userOperations: SerializedUserOperation[] = [];
@@ -111,17 +144,10 @@ export const paymasterWithdrawThunk = createAsyncThunk<
     const deposit = deposits[i]!;
     const isLast = i === deposits.length - 1;
 
-    const privateKey = sharedPrivateKey
-      ?? (delegation?.mode === 'deterministic'
-          ? await secretManager.deriveEphemeralSigner({
-              depositIndex: deposit.index,
-              chainId: bigintChainId,
-              poolAddress: deposit.pool,
-            })
-          : generatePrivateKey());
+    const signer = sharedDelegator ?? await resolveIndependentSigner(deposit);
 
-    const recipient = sharedPrivateKey
-      ? BigInt(ephemeralSenderAddress(privateKey)) as Address
+    const recipient = sharedDelegator
+      ? BigInt(signer.address) as Address
       : originalRecipient;
 
     // Only the final userOp in a tailCalls batch carries the execution phase.
@@ -161,7 +187,7 @@ export const paymasterWithdrawThunk = createAsyncThunk<
 
     userOperations.push(
       await buildSignedTornadoUserOp({
-        privateKey,
+        signer,
         chainId,
         paymasterAddress,
         paymasterData,
@@ -169,9 +195,9 @@ export const paymasterWithdrawThunk = createAsyncThunk<
         maxFeePerGas,
         maxPriorityFeePerGas,
         tailCalls: effectiveTailCalls,
-        // When sharing one ephemeral key across multiple deposits each userOp
-        // needs a distinct nonce (0, 1, 2 …) on the shared sender.
-        nonce: sharedPrivateKey ? BigInt(i) : 0n,
+        // When sharing one delegator across multiple deposits each userOp needs
+        // a distinct nonce (0, 1, 2 …) on the shared sender.
+        nonce: sharedDelegator ? BigInt(i) : 0n,
       }),
     );
   }


### PR DESCRIPTION
## Summary

Open the paymaster-withdrawal pipeline to **arbitrary signers** for the EIP-7702 delegator. Until now `buildSignedTornadoUserOp` always reconstructed the userOp sender via `privateKeyToAccount(privateKey)` with a key from our keystore, so integrators couldn't plug in hardware wallets, remote signers, or any viem `LocalAccount` they controlled.

The delegator is now an _injection seam_: a `DelegatorAccount` (a viem `LocalAccount`-shaped object — `address`, `signTypedData`, `signAuthorization`) is passed in from the thunk. Any signer that satisfies that contract — `privateKeyToAccount`, hardware wallets via WalletConnect, a remote-signer abstraction, etc. — can be the userOp sender.
