### PR TITLE
docs: fix Tornado Cash package installation

### DIFF
--- a/docs/pages/tornado/intro.mdx
+++ b/docs/pages/tornado/intro.mdx
@@ -2,24 +2,24 @@
 
 ## Installation
 
-Install [@kohaku-eth/tornado](https://www.npmjs.com/package/@kohaku-eth/tornado) via your package manager of choice.
+Install [@kohaku-eth/tornado-cash](https://www.npmjs.com/package/@kohaku-eth/tornado-cash) via your package manager of choice.
 
 :::code-group
 
 ```bash [npm]
-npm install @kohaku-eth/tornado
+npm install @kohaku-eth/tornado-cash
 ```
 
 ```bash [pnpm]
-pnpm install @kohaku-eth/tornado
+pnpm add @kohaku-eth/tornado-cash
 ```
 
 ```bash [yarn]
-yarn install @kohaku-eth/tornado
+yarn add @kohaku-eth/tornado-cash
 ```
 
 ```bash [bun]
-bun install @kohaku-eth/tornado
+bun add @kohaku-eth/tornado-cash
 ```
 
 :::


### PR DESCRIPTION
## Summary

- update the Tornado Cash installation docs to reference the published `@kohaku-eth/tornado-cash` package
- update the npm package link accordingly
- use the package managers' dependency-add commands for pnpm, Yarn, and Bun

## Validation

- `npm view @kohaku-eth/tornado-cash name version dist-tags --json`
- `git diff --check`
- `CI=true pnpm --filter docs lint`
- `CI=true pnpm --filter docs build`