### PR TITLE
docs: fix plugins host interface link

### DIFF
--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -56,7 +56,7 @@ export type PluginInstance = {
 
 When initializing a plugin, the host (the consuming app) provides a set of standardized interfaces. Plugins uses these interfaces to interact with the host environment, store data, and perform actions on behalf of the user.
 
-[File: src/host.ts](./src/host.ts)
+[File: src/host/index.ts](./src/host/index.ts)
 ```ts
 export type Host = {
     network: Network;


### PR DESCRIPTION
## Summary

- update the plugins README to link to the current Host interface source file

## Validation

- `git diff --check`
- verified `packages/plugins/src/host/index.ts` exists and the obsolete `packages/plugins/src/host.ts` path does not