### PR TITLE
feat: privacy pools v1 paymaster

### DIFF
--- a/packages/privacy-pools/package.json
+++ b/packages/privacy-pools/package.json
@@ -72,6 +72,8 @@
     "viem": "^2.51.3"
   },
   "devDependencies": {
+    "@privacy-paymasters/sdk": "0.0.5",
+    "@saga-sync/client": "^0.1.4",
     "@types/node": "^24.1.0",
     "dotenv": "^17.2.1",
     "ethers": "^6.16.0",

--- a/packages/privacy-pools/src/account/keys.ts
+++ b/packages/privacy-pools/src/account/keys.ts
@@ -40,6 +40,16 @@ type DeriveSecretsParams = BaseDeriveSecretParams & {
 export interface ISecretManager {
   getDepositSecrets: (params: DeriveDepositSecretParams) => Promise<Secret>;
   getSecrets: (params: DeriveWithdrawalSecretsParams) => Promise<Secret>;
+  /**
+   * Derives the private key of the ephemeral EOA that sends a paymaster-sponsored
+   * withdrawal userOp. Deterministic per (accountIndex, chainId, entrypoint,
+   * depositIndex, withdrawIndex), so a stuck sender is recoverable. The
+   * withdrawIndex is required because privacy pools supports partial withdrawals:
+   * the same deposit is spent across multiple userOps, each of which must use a
+   * fresh single-use sender (nonce 0, one EIP-7702 authorization). The value is a
+   * poseidon field element, which is always a valid secp256k1 scalar.
+   */
+  deriveEphemeralSigner: (params: DeriveWithdrawalSecretsParams) => Promise<`0x${string}`>;
 }
 
 export interface SecretManagerParams {
@@ -71,9 +81,17 @@ export function SecretManager({
     return deriveSecrets({ entrypointAddress, chainId, depositIndex, secretIndex: withdrawIndex });
   };
 
+  const deriveEphemeralSigner = async ({ chainId, entrypointAddress, depositIndex, withdrawIndex }: DeriveWithdrawalSecretsParams) => {
+    const raw = await keystore.deriveAt(ppSignerPath({ accountIndex, depositIndex, withdrawIndex }));
+    const key = hashToSnarkField([chainId.toString(), BigInt(entrypointAddress), BigInt(raw)]);
+
+    return `0x${key.toString(16).padStart(64, "0")}` as `0x${string}`;
+  };
+
   return {
     getDepositSecrets,
-    getSecrets
+    getSecrets,
+    deriveEphemeralSigner,
   };
 
 }
@@ -85,10 +103,18 @@ type PrivacyPoolsDerivationPath = {
   secretIndex: number;
 };
 
+// secretType index 2 (0 = nullifier, 1 = salt) reserved for the paymaster
+// ephemeral signer, disjoint from the note-secret lineage.
+const SIGNER_SECRET_TYPE = 2;
+
 function ppPath({ accountIndex, secretType, depositIndex, secretIndex }: PrivacyPoolsDerivationPath) {
   const _secretType = secretType === "nullifier" ? 0 : 1;
 
   return `${PRIVACY_POOLS_PATH}/${accountIndex}'/${_secretType}'/${depositIndex}'/${secretIndex}'`;
+}
+
+function ppSignerPath({ accountIndex, depositIndex, withdrawIndex }: { accountIndex: number; depositIndex: number; withdrawIndex: number }) {
+  return `${PRIVACY_POOLS_PATH}/${accountIndex}'/${SIGNER_SECRET_TYPE}'/${depositIndex}'/${withdrawIndex}'`;
 }
 
 function hashToSnarkField(numberLikes: (string | bigint)[]) {

--- a/packages/privacy-pools/src/config.ts
+++ b/packages/privacy-pools/src/config.ts
@@ -1,5 +1,34 @@
+import { IChainsPaymastersConfig } from "./plugin/interfaces/protocol-params.interface";
+
 // Protocol constants
 export const E_ADDRESS = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
+/**
+ * Per-chain paymaster wiring for sponsored withdrawals. Addresses are
+ * placeholders pending the on-chain deployment (contracts are out of scope for
+ * this cut); `poolsAccountsMap` routes each pool (lowercase hex) to its adapter.
+ */
+export const PrivacyPoolsPaymasterConfigs: IChainsPaymastersConfig = {
+  11155111: {
+    bundlerUrl: "https://public.pimlico.io/v2/11155111/rpc",
+    entryPointAddress: "0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108",
+    paymasterAddress: "0x0000000000000000000000000000000000000000",
+    poolsAccountsMap: {},
+  },
+  1: {
+    bundlerUrl: "https://public.pimlico.io/v2/1/rpc",
+    entryPointAddress: "0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108",
+    paymasterAddress: "0xe06CB96C57D2442f8F60F5017354BC08F7e91308",
+    poolsAccountsMap: {
+      // ETH pool -> privacypools_simple_eth adapter
+      "0xf241d57c6debae225c0f2e6ea1529373c9a9c9fb": "0x0a230D83f16209E2692494a0ae139aAD8C96bde9",
+      // USDT pool -> privacypools_complex_usdt_100 adapter
+      "0xe859c0bd25f260baee534fb52e307d3b64d24572": "0xFcA5515D05f372Db8E03Bcc6b1a96BF4aC006f33",
+      // USDC pool -> privacypools_complex_usdc_100 adapter
+      "0xb419c2867ab3cbc78921660cb95150d95a94ce86": "0x16B7d484c634985FbafaaaC6f3ee14e9eFDa4889",
+    },
+  },
+};
 
 export const PrivacyPoolsV1_0xBow = {
   1: {

--- a/packages/privacy-pools/src/data/abis/account.abi.ts
+++ b/packages/privacy-pools/src/data/abis/account.abi.ts
@@ -1,0 +1,35 @@
+import { Abi } from "viem";
+
+// Canonical Simple7702Account (EntryPoint v0.8) execution entrypoints, used to
+// encode the userOp `callData` for a paymaster withdrawal's execution phase
+// (tail calls). The ephemeral sender is 7702-delegated to this implementation.
+export const SIMPLE_7702_EXECUTE_ABI = [
+  {
+    name: "execute",
+    type: "function",
+    inputs: [
+      { name: "target", type: "address" },
+      { name: "value", type: "uint256" },
+      { name: "data", type: "bytes" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    name: "executeBatch",
+    type: "function",
+    inputs: [
+      {
+        name: "calls",
+        type: "tuple[]",
+        components: [
+          { name: "target", type: "address" },
+          { name: "value", type: "uint256" },
+          { name: "data", type: "bytes" },
+        ],
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+] as const satisfies Abi;

--- a/packages/privacy-pools/src/data/abis/paymaster.abi.ts
+++ b/packages/privacy-pools/src/data/abis/paymaster.abi.ts
@@ -1,0 +1,14 @@
+import type { Abi } from "viem";
+
+export const paymasterAbi = [
+  {
+    type: "function",
+    name: "quoteWeiInToken",
+    stateMutability: "view",
+    inputs: [
+      { name: "feeToken", type: "address" },
+      { name: "weiAmount", type: "uint256" },
+    ],
+    outputs: [{ name: "tokenAmount", type: "uint256" }],
+  },
+] as const satisfies Abi;

--- a/packages/privacy-pools/src/data/data.service.ts
+++ b/packages/privacy-pools/src/data/data.service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { EthereumProvider, TxLog } from "@kohaku-eth/provider";
 import {
   GetEventsFn,
@@ -13,7 +14,7 @@ import {
   POOL_EVENTS_SIGNATURES,
 } from "./abis/events.abi";
 import { EVENTS_PARSERS } from "./utils/events-parsers.util";
-import { EthClient } from "./eth-client";
+import { EthClient, GetLogsParams } from "./eth-client";
 import type { IAsset } from "./interfaces/events.interface";
 import { Address } from "../interfaces/types.interface";
 import { E_ADDRESS } from "../config";
@@ -38,6 +39,13 @@ const txLogToRpcLog = ({
 
 export interface DataServiceParams {
   provider: EthereumProvider;
+  /**
+   * Optional override for event-log fetching. Lets a test (or an alternative
+   * hydration source such as saga-sync) supply logs without changing how the
+   * rest of the service reads chain state via the provider. Defaults to the
+   * provider-backed `EthClient.getLogs`.
+   */
+  getLogs?: (params: GetLogsParams) => Promise<TxLog[]>;
 }
 
 const depositEvents = new Set(["PoolDeposited", "EntrypointDeposited"]);
@@ -49,9 +57,11 @@ type GenericGetEvents = GetEventsFn<
 
 export class DataService implements IDataService {
   private readonly ethClient!: EthClient;
+  private readonly getLogs: (params: GetLogsParams) => Promise<TxLog[]>;
 
-  constructor({ provider }: DataServiceParams) {
+  constructor({ provider, getLogs }: DataServiceParams) {
     this.ethClient = new EthClient(provider);
+    this.getLogs = getLogs ?? ((params) => this.ethClient.getLogs(params));
   }
 
   private getEvents: GenericGetEvents = async ({
@@ -61,7 +71,7 @@ export class DataService implements IDataService {
     toBlock,
   }) => {
 
-    const logs = await this.ethClient.getLogs({
+    const logs = await this.getLogs({
       address: pad(toHex(address), { size: 20 }),
       fromBlock,
       ...(toBlock ? { toBlock } : {}),
@@ -178,6 +188,20 @@ export class DataService implements IDataService {
 
   async getEntrypointRootByIndex(entrypointAddress: Address, index: number): Promise<bigint> {
     return this.ethClient.makeContractRequest(entrypointAddress, "entrypoint", "rootByIndex", BigInt(index));
+  }
+
+  async quoteWeiInToken(
+    paymasterAddress: Address,
+    feeToken: Address,
+    weiAmount: bigint,
+  ): Promise<bigint> {
+    return this.ethClient.makeContractRequest(
+      paymasterAddress,
+      "paymaster",
+      "quoteWeiInToken",
+      toHex(feeToken, { size: 20 }),
+      weiAmount,
+    );
   }
 
   async getLatestBlockTimestamp(): Promise<bigint> {

--- a/packages/privacy-pools/src/data/eth-client.ts
+++ b/packages/privacy-pools/src/data/eth-client.ts
@@ -2,6 +2,7 @@ import type { EthereumProvider, TxLog } from "@kohaku-eth/provider";
 import { ContractFunctionName, decodeFunctionResult, DecodeFunctionResultReturnType, encodeFunctionData, EncodeFunctionDataParameters, erc20Abi, toHex } from 'viem';
 import { Address } from "../interfaces/types.interface";
 import { entrypointAbi } from "./abis/entrypoint.abi";
+import { paymasterAbi } from "./abis/paymaster.abi";
 import { poolAbi } from "./abis/pool.abi";
 
 export interface GetLogsParams {
@@ -15,6 +16,7 @@ const abis = {
     erc20: erc20Abi,
     pool: poolAbi,
     entrypoint: entrypointAbi,
+    paymaster: paymasterAbi,
 } as const;
 
 export class EthClient {

--- a/packages/privacy-pools/src/data/interfaces/data.service.interface.ts
+++ b/packages/privacy-pools/src/data/interfaces/data.service.interface.ts
@@ -84,4 +84,14 @@ export interface IDataService {
   getEntrypointLatestRoot(entrypointAddress: Address): Promise<bigint>;
   getEntrypointRootByIndex(entrypointAddress: Address, index: number): Promise<bigint>;
   getLatestBlockTimestamp(): Promise<bigint>;
+  /**
+   * Prices a wei-denominated gas fee in `feeToken` via the paymaster's own
+   * oracle (same pool/TWAP it enforces during validation), so feePaid >= required
+   * holds by construction for paymaster-sponsored withdrawals.
+   */
+  quoteWeiInToken(
+    paymasterAddress: Address,
+    feeToken: Address,
+    weiAmount: bigint,
+  ): Promise<bigint>;
 }

--- a/packages/privacy-pools/src/interfaces/user-ops.interface.ts
+++ b/packages/privacy-pools/src/interfaces/user-ops.interface.ts
@@ -1,0 +1,74 @@
+import type { LocalAccount } from "viem/accounts";
+
+/**
+ * The subset of a signing account the paymaster withdrawal flow needs. In the
+ * EIP-7702 Simple7702 design the ephemeral sender *is* the userOp sender, so it
+ * must sign both the 7702 authorization and the userOp hash. A viem
+ * `LocalAccount` (via `privateKeyToAccount`) satisfies this structurally.
+ */
+export type DelegatorAccount = Pick<LocalAccount, "address" | "signTypedData"> & {
+  signAuthorization: NonNullable<LocalAccount["signAuthorization"]>;
+};
+
+/**
+ * How the ephemeral sender for a paymaster withdrawal is produced.
+ *
+ * - `deterministic` (default): recoverable — keyed by the withdrawn note's
+ *   deposit index via the SecretManager, so a stuck sender can be swept.
+ * - `random`: a throwaway, unrecoverable EOA. Safe here because in the
+ *   single-note flow the funds go straight to the recipient during paymaster
+ *   validation and never sit in the sender.
+ */
+export type DelegationConfig = { mode: "deterministic" } | { mode: "random" };
+
+export interface SerializedAuth {
+  address: `0x${string}`;
+  chainId: `0x${string}`;
+  nonce: `0x${string}`;
+  r: `0x${string}`;
+  s: `0x${string}`;
+  yParity: `0x${string}`;
+}
+
+/**
+ * A userOp serialized to the hex shape expected by `eth_sendUserOperation`, so
+ * it can be carried as plain (JSON-serializable) data from the prepare phase
+ * (thunk) to the broadcast phase.
+ */
+export interface SerializedUserOperation {
+  sender: `0x${string}`;
+  nonce: `0x${string}`;
+  callData: `0x${string}`;
+  callGasLimit: `0x${string}`;
+  verificationGasLimit: `0x${string}`;
+  preVerificationGas: `0x${string}`;
+  maxFeePerGas: `0x${string}`;
+  maxPriorityFeePerGas: `0x${string}`;
+  paymaster?: `0x${string}`;
+  paymasterVerificationGasLimit?: `0x${string}`;
+  paymasterPostOpGasLimit?: `0x${string}`;
+  paymasterData?: `0x${string}`;
+  signature: `0x${string}`;
+  eip7702Auth?: SerializedAuth;
+}
+
+export interface UserOpGasLimits {
+  callGasLimit: bigint;
+  verificationGasLimit: bigint;
+  preVerificationGas: bigint;
+  paymasterVerificationGasLimit: bigint;
+  paymasterPostOpGasLimit: bigint;
+}
+
+export interface BuildSignedUserOpParams {
+  /** The ephemeral account that becomes the userOp sender; signs the 7702 auth and the userOp hash. */
+  signer: DelegatorAccount;
+  chainId: number;
+  paymasterAddress: `0x${string}`;
+  paymasterData: `0x${string}`;
+  gas: UserOpGasLimits;
+  maxFeePerGas: bigint;
+  maxPriorityFeePerGas: bigint;
+  /** EntryPoint nonce for this sender. Defaults to 0 (fresh single-use EOA). */
+  nonce?: bigint;
+}

--- a/packages/privacy-pools/src/interfaces/user-ops.interface.ts
+++ b/packages/privacy-pools/src/interfaces/user-ops.interface.ts
@@ -1,3 +1,4 @@
+import type { TxData } from "@kohaku-eth/provider";
 import type { LocalAccount } from "viem/accounts";
 
 /**
@@ -71,4 +72,10 @@ export interface BuildSignedUserOpParams {
   maxPriorityFeePerGas: bigint;
   /** EntryPoint nonce for this sender. Defaults to 0 (fresh single-use EOA). */
   nonce?: bigint;
+  /**
+   * Optional execution-phase calls run by the Simple7702 sender after the
+   * withdrawal (which pays the sender during validation). Empty → callData `0x`;
+   * one call → `execute`; many → `executeBatch`.
+   */
+  tailCalls?: (sender: `0x${string}`) => Promise<TxData[]>;
 }

--- a/packages/privacy-pools/src/paymaster/adapter-data.ts
+++ b/packages/privacy-pools/src/paymaster/adapter-data.ts
@@ -1,0 +1,56 @@
+import { encodeAbiParameters, parseAbiParameters } from "viem";
+
+import { WithdrawalPayload } from "../relayer/interfaces/relayer-client.interface";
+import { WithdrawProveOutput } from "../state/thunks/withdrawThunk";
+import { toWithdrawProof } from "../utils/encoding.utils";
+
+/**
+ * Encodes the userOp `paymasterData` field for the PrivacyPaymaster:
+ * `abi.encode(PaymasterData{ address adapter; bytes adapterData })`.
+ *
+ * (Matches `@privacy-paymasters/sdk`'s `encodePaymasterData`; kept local so the
+ * SDK stays a test-only dependency.)
+ */
+export function encodePaymasterData(
+  adapter: `0x${string}`,
+  adapterData: `0x${string}`,
+): `0x${string}` {
+  return encodeAbiParameters(parseAbiParameters("(address adapter, bytes adapterData)"), [
+    { adapter, adapterData },
+  ]);
+}
+
+/**
+ * Encodes the paymaster `withdrawal.data` bytes the PrivacyPoolsFeeAdapter
+ * expects: `abi.encode(FeeData{ address recipient; address feeRecipient; uint256 fee })`.
+ * `fee` is an absolute amount in the pool asset (not basis points); `feeRecipient`
+ * must be the paymaster. Bound into the proof's `context` signal.
+ */
+export function encodeFeeData(feeData: {
+  recipient: `0x${string}`;
+  feeRecipient: `0x${string}`;
+  fee: bigint;
+}): `0x${string}` {
+  return encodeAbiParameters(
+    parseAbiParameters("(address recipient, address feeRecipient, uint256 fee)"),
+    [feeData],
+  );
+}
+
+/**
+ * Encodes the PrivacyPoolsFeeAdapter's `adapterData`:
+ * `abi.encode(AdapterData{ Withdrawal withdrawal; WithdrawProof proof })`. The
+ * adapter acts as the withdrawal `processooor` and calls `pool.withdraw` directly
+ * during paymaster validation.
+ */
+export function encodePrivacyPoolAdapterData(
+  withdrawal: WithdrawalPayload,
+  proof: WithdrawProveOutput,
+): `0x${string}` {
+  return encodeAbiParameters(
+    parseAbiParameters(
+      "((address processooor, bytes data) withdrawal, (uint256[2] pA, uint256[2][2] pB, uint256[2] pC, uint256[8] pubSignals) proof)",
+    ),
+    [{ withdrawal, proof: toWithdrawProof(proof) }],
+  );
+}

--- a/packages/privacy-pools/src/paymaster/fee.ts
+++ b/packages/privacy-pools/src/paymaster/fee.ts
@@ -2,6 +2,11 @@ import { UserOpGasLimits } from "../interfaces/user-ops.interface";
 
 const ERC20_TRANSFER_GAS = 100_000n;
 
+// Default execution-phase (callData) budget when a withdrawal carries tail calls
+// and the caller supplies no estimate. Covers a simple forward/transfer; complex
+// tail calls should pass an explicit `tailCallsGasEstimate`.
+export const TAIL_CALLS_DEFAULT_GAS = 300_000n;
+
 // Conservative ceilings for a single-note paymaster withdrawal. The groth16
 // verify + 2-depth state/ASP merkle path plus the adapter's inline
 // entrypoint.relay run inside paymaster validation, so their cost lives in

--- a/packages/privacy-pools/src/paymaster/fee.ts
+++ b/packages/privacy-pools/src/paymaster/fee.ts
@@ -1,0 +1,60 @@
+import { UserOpGasLimits } from "../interfaces/user-ops.interface";
+
+const ERC20_TRANSFER_GAS = 100_000n;
+
+// Conservative ceilings for a single-note paymaster withdrawal. The groth16
+// verify + 2-depth state/ASP merkle path plus the adapter's inline
+// entrypoint.relay run inside paymaster validation, so their cost lives in
+// paymasterVerificationGasLimit — callGasLimit is 0 in this flow (funds go
+// straight to the recipient during validation). These are refined against the
+// bundler's own simulation when available; see `refineGasWithBundler`.
+//
+// NOTE: privacy-pools circuits differ from tornado-cash's — these baselines are
+// a starting point and should be re-measured against a real proof + adapter.
+const baseGasUnits: UserOpGasLimits = {
+  preVerificationGas: 100_000n,
+  verificationGasLimit: 50_000n,
+  callGasLimit: 300_000n,
+  // The whole withdrawal runs inside paymaster validation: paymaster ->
+  // adapter.collectFee -> pool.withdraw (groth16 verify + merkle + change-note
+  // insert + payout). Nested external calls each lose 1/64 of the forwarded gas
+  // (EIP-150), and bundler estimation can't refine this (simulation itself OOGs
+  // below the true cost), so the baseline must comfortably cover it on its own.
+  paymasterVerificationGasLimit: 1_200_000n,
+  paymasterPostOpGasLimit: 50_000n,
+};
+
+export function reasonableGasUnits(isERC20: boolean): UserOpGasLimits {
+  if (!isERC20) return baseGasUnits;
+
+  // The fee-paying transfer for ERC20 pools runs inside the adapter during
+  // paymaster validation, so its cost belongs to paymasterVerificationGasLimit,
+  // not callGasLimit (which is 0 in this flow).
+  return {
+    ...baseGasUnits,
+    paymasterVerificationGasLimit: baseGasUnits.paymasterVerificationGasLimit + ERC20_TRANSFER_GAS,
+  };
+}
+
+/** The fee amount (in wei) the paymaster expects to break even for these gas limits. */
+export function computeMinimumViableFee(
+  gasUnits: UserOpGasLimits,
+  maxFeePerGas: bigint,
+): bigint {
+  // 1.2x base-fee multiplier (matches viem's estimateFeesPerGas heuristic).
+  const baseFeeMultiplier = 1.2;
+  const decimals = baseFeeMultiplier.toString().split(".")[1]?.length ?? 0;
+  const denominator = 10 ** decimals;
+  const multiply = (base: bigint) =>
+    (base * BigInt(Math.ceil(baseFeeMultiplier * denominator))) / BigInt(denominator);
+
+  // EntryPoint's requiredPrefund = sum(all gas limits) * maxFeePerGas.
+  const requiredGas =
+    gasUnits.verificationGasLimit +
+    gasUnits.callGasLimit +
+    gasUnits.paymasterVerificationGasLimit +
+    gasUnits.preVerificationGas +
+    gasUnits.paymasterPostOpGasLimit;
+
+  return multiply(requiredGas * maxFeePerGas);
+}

--- a/packages/privacy-pools/src/paymaster/paymaster-broadcaster.ts
+++ b/packages/privacy-pools/src/paymaster/paymaster-broadcaster.ts
@@ -1,0 +1,51 @@
+import { createPaymasterBundlerClient, sendSerializedUserOperation } from "./utils";
+import {
+  IGenericPaymasterWithdrawalPayload,
+  IPaymasterBroadcasterClient,
+  PaymasterBroadcastResult,
+} from "../relayer/interfaces/paymaster-client.interface";
+
+/**
+ * Relays paymaster-sponsored withdrawals to the bundler. The userOps are fully
+ * built and signed during the prepare phase (see `paymasterWithdrawThunk`), so
+ * this client only forwards them and awaits their receipts.
+ */
+export class PaymasterBroadcaster implements IPaymasterBroadcasterClient {
+  async broadcast(
+    withdrawals: IGenericPaymasterWithdrawalPayload[],
+  ): Promise<PaymasterBroadcastResult[]> {
+    const results = await Promise.allSettled(
+      withdrawals.map((w) => PaymasterBroadcaster.broadcastOne(w)),
+    );
+
+    const failed = results.filter((r) => r.status === "rejected");
+
+    if (failed.length > 0) {
+      console.warn(
+        `Some paymaster withdrawals failed.`,
+        failed.map((e) => (e as PromiseRejectedResult).reason).join("\n"),
+      );
+    }
+
+    return results
+      .filter((r): r is PromiseFulfilledResult<PaymasterBroadcastResult> => r.status === "fulfilled")
+      .map((r) => r.value);
+  }
+
+  static async broadcastOne(
+    withdrawal: IGenericPaymasterWithdrawalPayload,
+  ): Promise<PaymasterBroadcastResult> {
+    const { bundlerUrl, entryPointAddress, userOperation } = withdrawal;
+
+    const bundlerClient = createPaymasterBundlerClient(bundlerUrl);
+    const userOpHash = await sendSerializedUserOperation(
+      bundlerClient,
+      userOperation,
+      entryPointAddress,
+    );
+
+    const { receipt } = await bundlerClient.waitForUserOperationReceipt({ hash: userOpHash });
+
+    return { userOpHash, txHash: receipt.transactionHash };
+  }
+}

--- a/packages/privacy-pools/src/paymaster/utils.ts
+++ b/packages/privacy-pools/src/paymaster/utils.ts
@@ -1,0 +1,191 @@
+import {
+  http,
+  toHex,
+  type Address,
+  type Hash,
+  type SignedAuthorization,
+} from "viem";
+import {
+  createBundlerClient,
+  entryPoint08Address,
+  getUserOperationTypedData,
+  type BundlerClient,
+} from "viem/account-abstraction";
+
+import {
+  BuildSignedUserOpParams,
+  SerializedAuth,
+  SerializedUserOperation,
+  UserOpGasLimits,
+} from "../interfaces/user-ops.interface";
+
+/**
+ * EntryPoint v0.8 canonical Simple7702Account implementation. The ephemeral
+ * withdrawal sender is 7702-delegated to this contract, whose `validateUserOp`
+ * checks an owner ECDSA signature over the userOp hash.
+ */
+export const SIMPLE_7702_IMPLEMENTATION = "0xe6Cae83BdE06E4c305530e199D7217f42808555B" as const;
+
+export type GasPrice = {
+  maxFeePerGas: bigint;
+  maxPriorityFeePerGas: bigint;
+};
+
+export type UserOperationGasPrice = {
+  slow: GasPrice;
+  standard: GasPrice;
+  fast: GasPrice;
+};
+
+/** viem bundler client for the paymaster flow. */
+export function createPaymasterBundlerClient(bundlerUrl: string): BundlerClient {
+  return createBundlerClient({ transport: http(bundlerUrl) });
+}
+
+/**
+ * Pimlico gas-price oracle (`pimlico_getUserOperationGasPrice`). Not a standard
+ * ERC-4337 bundler method, so we issue the raw request and parse the tiers.
+ */
+export async function getUserOperationGasPrice(
+  client: BundlerClient,
+): Promise<UserOperationGasPrice> {
+  const result = (await client.request({
+    method: "pimlico_getUserOperationGasPrice",
+    params: [],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any)) as any;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const parse = (tier: any): GasPrice => ({
+    maxFeePerGas: BigInt(tier.maxFeePerGas),
+    maxPriorityFeePerGas: BigInt(tier.maxPriorityFeePerGas),
+  });
+
+  return {
+    slow: parse(result.slow),
+    standard: parse(result.standard),
+    fast: parse(result.fast),
+  };
+}
+
+/** Sends an already-built, serialized (hex) userOp directly to the bundler. */
+export async function sendSerializedUserOperation(
+  client: BundlerClient,
+  op: SerializedUserOperation,
+  entryPoint: Address,
+): Promise<Hash> {
+  return client.request({
+    method: "eth_sendUserOperation",
+    params: [op, entryPoint],
+  }) as Promise<Hash>;
+}
+
+/**
+ * Bundler gas estimation (`eth_estimateUserOperationGas`) for an already-built,
+ * serialized userOp. Best-effort: callers should fall back to static limits on
+ * failure.
+ */
+export async function estimateUserOperationGas(
+  client: BundlerClient,
+  op: SerializedUserOperation,
+  entryPoint: Address,
+): Promise<UserOpGasLimits> {
+  const result = (await client.request({
+    method: "eth_estimateUserOperationGas",
+    params: [op, entryPoint],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any)) as any;
+
+  return {
+    callGasLimit: BigInt(result.callGasLimit),
+    verificationGasLimit: BigInt(result.verificationGasLimit),
+    preVerificationGas: BigInt(result.preVerificationGas),
+    paymasterVerificationGasLimit: BigInt(result.paymasterVerificationGasLimit ?? 0),
+    paymasterPostOpGasLimit: BigInt(result.paymasterPostOpGasLimit ?? 0),
+  };
+}
+
+/**
+ * Builds and signs a paymaster-sponsored withdrawal userOp for an ephemeral
+ * 7702 sender, returning it serialized for the broadcast phase. In the
+ * single-note flow the execution phase is empty (callData `0x`): the withdrawal
+ * happens during paymaster validation and funds go straight to the recipient.
+ *
+ * The sender is a fresh EOA (EntryPoint nonce 0) delegated to the Simple7702
+ * implementation; the owner signs the userOp. No RPC access is required.
+ */
+export async function buildSignedUserOp({
+  signer,
+  chainId,
+  paymasterAddress,
+  paymasterData,
+  gas,
+  maxFeePerGas,
+  maxPriorityFeePerGas,
+  nonce = 0n,
+}: BuildSignedUserOpParams): Promise<SerializedUserOperation> {
+  const owner = signer;
+
+  // The EIP-7702 authorization nonce must equal the sender's EOA nonce at bundle
+  // time; a fresh single-use sender has nonce 0.
+  const authorization = await owner.signAuthorization({
+    address: SIMPLE_7702_IMPLEMENTATION,
+    chainId,
+    nonce: Number(nonce),
+  });
+
+  const userOperation = {
+    sender: owner.address,
+    nonce,
+    callData: "0x" as const,
+    callGasLimit: gas.callGasLimit,
+    verificationGasLimit: gas.verificationGasLimit,
+    preVerificationGas: gas.preVerificationGas,
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+    paymaster: paymasterAddress,
+    paymasterVerificationGasLimit: gas.paymasterVerificationGasLimit,
+    paymasterPostOpGasLimit: gas.paymasterPostOpGasLimit,
+    paymasterData,
+  };
+
+  const signature = await owner.signTypedData(
+    getUserOperationTypedData({
+      chainId,
+      entryPointAddress: entryPoint08Address,
+      // viem's type requires a `signature`, but the userOp typedData does not contain one.
+      userOperation: userOperation as unknown as Parameters<
+        typeof getUserOperationTypedData
+      >[0]["userOperation"],
+    }),
+  );
+
+  return {
+    sender: userOperation.sender,
+    nonce: toHex(userOperation.nonce),
+    callData: userOperation.callData,
+    callGasLimit: toHex(userOperation.callGasLimit),
+    verificationGasLimit: toHex(userOperation.verificationGasLimit),
+    preVerificationGas: toHex(userOperation.preVerificationGas),
+    maxFeePerGas: toHex(userOperation.maxFeePerGas),
+    maxPriorityFeePerGas: toHex(userOperation.maxPriorityFeePerGas),
+    paymaster: userOperation.paymaster,
+    paymasterVerificationGasLimit: toHex(userOperation.paymasterVerificationGasLimit),
+    paymasterPostOpGasLimit: toHex(userOperation.paymasterPostOpGasLimit),
+    paymasterData: userOperation.paymasterData,
+    signature,
+    eip7702Auth: serializeAuth(authorization),
+  };
+}
+
+function serializeAuth(auth: SignedAuthorization): SerializedAuth {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    address: (auth as any).address ?? (auth as any).contractAddress,
+    chainId: toHex(auth.chainId),
+    nonce: toHex(auth.nonce),
+    r: auth.r,
+    s: auth.s,
+    yParity: toHex(auth.yParity!),
+  };
+}

--- a/packages/privacy-pools/src/paymaster/utils.ts
+++ b/packages/privacy-pools/src/paymaster/utils.ts
@@ -1,8 +1,11 @@
+/* eslint-disable max-lines */
 import {
+  encodeFunctionData,
   http,
   toHex,
   type Address,
   type Hash,
+  type Hex,
   type SignedAuthorization,
 } from "viem";
 import {
@@ -12,6 +15,7 @@ import {
   type BundlerClient,
 } from "viem/account-abstraction";
 
+import { SIMPLE_7702_EXECUTE_ABI } from "../data/abis/account.abi";
 import {
   BuildSignedUserOpParams,
   SerializedAuth,
@@ -107,9 +111,11 @@ export async function estimateUserOperationGas(
 
 /**
  * Builds and signs a paymaster-sponsored withdrawal userOp for an ephemeral
- * 7702 sender, returning it serialized for the broadcast phase. In the
- * single-note flow the execution phase is empty (callData `0x`): the withdrawal
- * happens during paymaster validation and funds go straight to the recipient.
+ * 7702 sender, returning it serialized for the broadcast phase. Without
+ * `tailCalls` the execution phase is empty (callData `0x`) and the withdrawal
+ * pays the recipient during paymaster validation. With `tailCalls`, the
+ * withdrawal pays the sender and the execution phase (`execute`/`executeBatch`)
+ * runs the caller's calls atomically.
  *
  * The sender is a fresh EOA (EntryPoint nonce 0) delegated to the Simple7702
  * implementation; the owner signs the userOp. No RPC access is required.
@@ -123,8 +129,28 @@ export async function buildSignedUserOp({
   maxFeePerGas,
   maxPriorityFeePerGas,
   nonce = 0n,
+  tailCalls,
 }: BuildSignedUserOpParams): Promise<SerializedUserOperation> {
   const owner = signer;
+
+  const calls = tailCalls ? await tailCalls(owner.address) : [];
+  let callData: Hex = "0x";
+
+  if (calls.length === 1) {
+    const call = calls[0]!;
+
+    callData = encodeFunctionData({
+      abi: SIMPLE_7702_EXECUTE_ABI,
+      functionName: "execute",
+      args: [call.to as Address, call.value, call.data as Hex],
+    });
+  } else if (calls.length > 1) {
+    callData = encodeFunctionData({
+      abi: SIMPLE_7702_EXECUTE_ABI,
+      functionName: "executeBatch",
+      args: [calls.map((c) => ({ target: c.to as Address, value: c.value, data: c.data as Hex }))],
+    });
+  }
 
   // The EIP-7702 authorization nonce must equal the sender's EOA nonce at bundle
   // time; a fresh single-use sender has nonce 0.
@@ -137,7 +163,7 @@ export async function buildSignedUserOp({
   const userOperation = {
     sender: owner.address,
     nonce,
-    callData: "0x" as const,
+    callData,
     callGasLimit: gas.callGasLimit,
     verificationGasLimit: gas.verificationGasLimit,
     preVerificationGas: gas.preVerificationGas,

--- a/packages/privacy-pools/src/plugin/base.ts
+++ b/packages/privacy-pools/src/plugin/base.ts
@@ -203,6 +203,8 @@ export class PrivacyPoolsV1Protocol implements PPv1Instance {
         amount,
         recipient: BigInt(to),
         delegation: options.delegation,
+        tailCalls: options.tailCalls,
+        tailCallsGasEstimate: options.tailCallsGasEstimate,
       });
 
       if (!withdrawal) throw new Error("We failed to create a paymaster withdrawalPayload");

--- a/packages/privacy-pools/src/plugin/base.ts
+++ b/packages/privacy-pools/src/plugin/base.ts
@@ -8,8 +8,10 @@ import {
 } from "@kohaku-eth/plugins";
 
 import { ISecretManager, SecretManager } from "../account/keys";
+import { PrivacyPoolsPaymasterConfigs } from "../config.js";
 import { IPFSAspService } from "../data/ipfsAsp.service.js";
 import { DataService } from "../data/data.service";
+import { IPaymasterBroadcasterClient } from "../relayer/interfaces/paymaster-client.interface";
 import { IRelayerClient } from "../relayer/interfaces/relayer-client.interface";
 import { RelayerClient } from "../relayer/relayer-client";
 import { storeStateManager } from "../state/state-manager";
@@ -25,8 +27,11 @@ import {
   IEntrypoint,
   INote,
   IStateManager,
+  PPv1PaymasterPrivateOperation,
   PPv1PrivateOperation,
   PPv1PublicOperation,
+  PPv1RelayerPrivateOperation,
+  PPv1UnshieldOptions,
   PrivacyPoolsV1ProtocolParams,
 } from "./interfaces/protocol-params.interface";
 import { TxData } from "@kohaku-eth/provider";
@@ -35,6 +40,7 @@ type RequireOnly<T, Keys extends keyof T> = Partial<T> & Pick<T, Keys>;
 
 export interface PPv1RelayerConstructorParams extends PPv1BroadcasterParameters {
   relayerClientFactory?: () => IRelayerClient;
+  paymasterClientFactory?: () => IPaymasterBroadcasterClient;
   host: Host;
 }
 
@@ -59,6 +65,8 @@ export class PrivacyPoolsV1Protocol implements PPv1Instance {
       aspServiceFactory = () => new IPFSAspService({ network: host.network, ipfsUrl }),
       relayerClientFactory = () => new RelayerClient({ network: host.network }),
       proverFactory = Prover,
+      paymasterConfig = PrivacyPoolsPaymasterConfigs,
+      dataService = new DataService({ provider: host.provider }),
     }: RequireOnly<PrivacyPoolsV1ProtocolParams, "entrypoint">,
   ) {
     this.accountIndex = accountIndex;
@@ -73,12 +81,13 @@ export class PrivacyPoolsV1Protocol implements PPv1Instance {
       initialState,
       secretManager: this.secretManager,
       aspService: aspServiceFactory(),
-      dataService: new DataService({ provider: host.provider }),
+      dataService,
       relayerClient: this.relayerClient,
       relayersList: this.relayersList,
       proverFactory,
       storageToSyncTo: host.storage,
       entrypoint,
+      paymasterConfig,
     });
   }
 
@@ -176,9 +185,9 @@ export class PrivacyPoolsV1Protocol implements PPv1Instance {
     return { txns: ragequitTxs } as PPv1PublicOperation;
   }
 
-  async prepareUnshield(assets: AssetAmount, to: AccountId): Promise<PPv1PrivateOperation> {
+  async prepareUnshield(assets: AssetAmount, to: AccountId, options?: PPv1UnshieldOptions): Promise<PPv1PrivateOperation> {
     const { asset, amount } = assets;
-  
+
     if (asset.__type === 'native') {
       throw new Error("Unshielding native assets is not supported in this version of the protocol");
     }
@@ -187,6 +196,19 @@ export class PrivacyPoolsV1Protocol implements PPv1Instance {
     const assetAddress = BigInt(asset.contract);
 
     await this.stateManager.sync();
+
+    if (options?.mode === 'paymaster') {
+      const [withdrawal] = await this.stateManager.getPaymasterWithdrawalPayloads({
+        asset: assetAddress,
+        amount,
+        recipient: BigInt(to),
+        delegation: options.delegation,
+      });
+
+      if (!withdrawal) throw new Error("We failed to create a paymaster withdrawalPayload");
+
+      return { mode: 'paymaster', withdrawal } as PPv1PaymasterPrivateOperation;
+    }
 
     const [result] = await this.stateManager.getWithdrawalPayloads({
       asset: assetAddress,
@@ -219,6 +241,7 @@ export class PrivacyPoolsV1Protocol implements PPv1Instance {
     );
 
     return {
+      mode: 'relayer',
       rawData,
       txData: {
         to: `0x${entrypoint.address.toString(16).padStart(40, "0")}`,
@@ -226,7 +249,7 @@ export class PrivacyPoolsV1Protocol implements PPv1Instance {
         value: 0n,
       },
       quoteData,
-    } as PPv1PrivateOperation;
+    } as PPv1RelayerPrivateOperation;
   }
 
   sync() {

--- a/packages/privacy-pools/src/plugin/broadcaster.ts
+++ b/packages/privacy-pools/src/plugin/broadcaster.ts
@@ -1,32 +1,45 @@
 import { IRelayerClient, ISuccessfullRelayResponse } from "../relayer/interfaces/relayer-client.interface";
+import { IPaymasterBroadcasterClient } from "../relayer/interfaces/paymaster-client.interface";
 import { RelayerClient } from "../relayer/relayer-client";
+import { PaymasterBroadcaster } from "../paymaster/paymaster-broadcaster";
 import { PPv1Broadcaster, PPv1BroadcasterParameters } from "../v1";
 import { PPv1RelayerConstructorParams } from "./base";
-import { PPv1PrivateOperation } from "./interfaces/protocol-params.interface";
+import { PPv1PaymasterPrivateOperation, PPv1PrivateOperation } from "./interfaces/protocol-params.interface";
 
 
 export class PrivacyPoolsBroadcaster implements PPv1Broadcaster {
   relayersList: Record<string, string> = {};
   private relayerClient: IRelayerClient;
+  private paymasterBroadcaster: IPaymasterBroadcasterClient;
 
   constructor({
-    host, relayerClientFactory = () => new RelayerClient({ network: host.network }), broadcasterUrl,
+    host,
+    relayerClientFactory = () => new RelayerClient({ network: host.network }),
+    broadcasterUrl,
+    paymasterClientFactory = () => new PaymasterBroadcaster(),
   }: PPv1RelayerConstructorParams) {
     this.relayerClient = relayerClientFactory();
     this.relayersList = this.parseRelayers(broadcasterUrl);
+    this.paymasterBroadcaster = paymasterClientFactory();
   }
 
   private parseRelayers(params: PPv1BroadcasterParameters["broadcasterUrl"]) {
     return typeof params === "string" ? { default: params } : params;
   }
 
-  async broadcast({
-    rawData: {
-      chainId, scope, proof: { proof, publicSignals }, withdrawalPayload,
-    }, quoteData: {
-      relayerId, quote: { feeCommitment },
-    },
-  }: PPv1PrivateOperation): Promise<ISuccessfullRelayResponse> {
+  async broadcast(operation: PPv1PrivateOperation): Promise<ISuccessfullRelayResponse> {
+    if (operation.mode === "paymaster") {
+      return this.broadcastViaPaymaster(operation);
+    }
+
+    const {
+      rawData: {
+        chainId, scope, proof: { proof, publicSignals }, withdrawalPayload,
+      }, quoteData: {
+        relayerId, quote: { feeCommitment },
+      },
+    } = operation;
+
     const relayerUrl = this.relayersList[relayerId];
 
     if (!relayerUrl) {
@@ -42,6 +55,23 @@ export class PrivacyPoolsBroadcaster implements PPv1Broadcaster {
       publicSignals,
       proof,
     });
+  }
 
+  private async broadcastViaPaymaster(
+    operation: PPv1PaymasterPrivateOperation,
+  ): Promise<ISuccessfullRelayResponse> {
+    const [result] = await this.paymasterBroadcaster.broadcast([operation.withdrawal]);
+
+    if (!result) {
+      throw new Error("Paymaster withdrawal failed to broadcast.");
+    }
+
+    // Normalize the userOp result into the relayer response shape callers expect.
+    return {
+      success: true,
+      timestamp: Date.now(),
+      requestId: result.userOpHash,
+      txHash: result.txHash,
+    };
   }
 }

--- a/packages/privacy-pools/src/plugin/interfaces/protocol-params.interface.ts
+++ b/packages/privacy-pools/src/plugin/interfaces/protocol-params.interface.ts
@@ -1,18 +1,23 @@
 import { CommitmentPublicSignals, Prover } from "@fatsolutions/privacy-pools-core-circuits";
-import { ChainId, PrivateOperation, PublicOperation } from '@kohaku-eth/plugins';
+import { ChainId, PrivateOperation, PublicOperation, UnshieldOptions } from '@kohaku-eth/plugins';
 import { TxData } from '@kohaku-eth/provider';
 
 import { ISecretManager, SecretManagerParams } from "../../account/keys";
 import { IAspService } from "../../data/asp.interface.js";
+import { IDataService } from "../../data/interfaces/data.service.interface";
 import { IDepositWithBalance } from "../../data/interfaces/events.interface";
 import { Address } from "../../interfaces/types.interface";
+import { DelegationConfig } from "../../interfaces/user-ops.interface";
+import { IGenericPaymasterWithdrawalPayload } from "../../relayer/interfaces/paymaster-client.interface";
 import { IQuoteResponse, IRelayData, IRelayerClient, WithdrawalPayload } from '../../relayer/interfaces/relayer-client.interface';
 import { PublicRootState } from "../../state/store";
 import { SpecificAssetBalanceFn } from "../../state/selectors/balance.selector";
 import { StoreFactoryParams } from "../../state/state-manager";
 import { WithdrawProveOutput } from "../../state/thunks/withdrawThunk";
 
-export interface PPv1PrivateOperation extends PrivateOperation {
+/** Withdrawal via a relayer that fronts gas (the default path). */
+export interface PPv1RelayerPrivateOperation extends PrivateOperation {
+  mode?: 'relayer';
   rawData: {
     context: bigint,
     relayData: IRelayData,
@@ -26,6 +31,32 @@ export interface PPv1PrivateOperation extends PrivateOperation {
     quote: IQuoteResponse;
     relayerId: string;
   };
+}
+
+/** Withdrawal sponsored by a paymaster via an ERC-4337 userOp. */
+export interface PPv1PaymasterPrivateOperation extends PrivateOperation {
+  mode: 'paymaster';
+  withdrawal: IGenericPaymasterWithdrawalPayload;
+}
+
+export type PPv1PrivateOperation =
+  | PPv1RelayerPrivateOperation
+  | PPv1PaymasterPrivateOperation;
+
+/** Per-chain paymaster wiring. `poolsAccountsMap` routes a pool address (lowercase hex) to its adapter. */
+export interface IPaymasterConfig {
+  bundlerUrl: string;
+  entryPointAddress: `0x${string}`;
+  paymasterAddress: `0x${string}`;
+  poolsAccountsMap: Record<string, `0x${string}`>;
+}
+
+export type IChainsPaymastersConfig = Record<number, IPaymasterConfig>;
+
+/** Extra `prepareUnshield` options: choose the broadcast path and, for paymaster, the sender derivation. */
+export interface PPv1UnshieldOptions extends UnshieldOptions {
+  mode?: 'relayer' | 'paymaster';
+  delegation?: DelegationConfig;
 }
 
 export interface PPv1PublicOperation extends PublicOperation {
@@ -48,6 +79,9 @@ export interface PrivacyPoolsV1ProtocolParams {
   relayersList: Record<string, string>;
   initialState?: () => Promise<Record<string, PublicRootState>>;
   ipfsUrl?: string;
+  paymasterConfig?: IChainsPaymastersConfig;
+  /** Optional pre-built data service (e.g. a saga-sync-backed one used to speed up hydration in tests). */
+  dataService?: IDataService;
 }
 
 interface IBaseOperationParams { }  // eslint-disable-line @typescript-eslint/no-empty-object-type
@@ -65,6 +99,10 @@ export interface IGetBalancesOperationParams extends IBaseOperationParams {
 export interface IWithdrawapOperationParams extends Omit<IDepositOperationParams, 'amount'> {
   amount?: bigint;
   recipient: Address;
+}
+
+export interface IPaymasterWithdrawapOperationParams extends IWithdrawapOperationParams {
+  delegation?: DelegationConfig;
 }
 
 export interface IRagequitAssetsOperationParams extends IBaseOperationParams {
@@ -129,6 +167,13 @@ export interface IStateManager {
    * Generates the relayer quotes and withdrawals payloads for the specified amount
    */
   getWithdrawalPayloads: (params: IWithdrawapOperationParams) => Promise<StateWithdrawalPayload[]>;
+  /**
+   * Generates paymaster-sponsored withdrawal payloads (fully built + signed userOps)
+   * for the specified amount. No relayer is involved.
+   */
+  getPaymasterWithdrawalPayloads: (
+    params: IPaymasterWithdrawapOperationParams,
+  ) => Promise<IGenericPaymasterWithdrawalPayload[]>;
   /**
    * Generates the ragequit payloads for the specified assets. Only unapproved
    * amount will be ragequitted.

--- a/packages/privacy-pools/src/plugin/interfaces/protocol-params.interface.ts
+++ b/packages/privacy-pools/src/plugin/interfaces/protocol-params.interface.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { CommitmentPublicSignals, Prover } from "@fatsolutions/privacy-pools-core-circuits";
 import { ChainId, PrivateOperation, PublicOperation, UnshieldOptions } from '@kohaku-eth/plugins';
 import { TxData } from '@kohaku-eth/provider';
@@ -57,6 +58,8 @@ export type IChainsPaymastersConfig = Record<number, IPaymasterConfig>;
 export interface PPv1UnshieldOptions extends UnshieldOptions {
   mode?: 'relayer' | 'paymaster';
   delegation?: DelegationConfig;
+  /** Gas budget for the paymaster execution phase when `tailCalls` are supplied. */
+  tailCallsGasEstimate?: bigint;
 }
 
 export interface PPv1PublicOperation extends PublicOperation {
@@ -103,6 +106,8 @@ export interface IWithdrawapOperationParams extends Omit<IDepositOperationParams
 
 export interface IPaymasterWithdrawapOperationParams extends IWithdrawapOperationParams {
   delegation?: DelegationConfig;
+  tailCalls?: (sender: `0x${string}`) => Promise<TxData[]>;
+  tailCallsGasEstimate?: bigint;
 }
 
 export interface IRagequitAssetsOperationParams extends IBaseOperationParams {

--- a/packages/privacy-pools/src/relayer/interfaces/paymaster-client.interface.ts
+++ b/packages/privacy-pools/src/relayer/interfaces/paymaster-client.interface.ts
@@ -1,0 +1,32 @@
+import type { Hash } from "viem";
+import { Address } from "../../interfaces/types.interface";
+import { SerializedUserOperation } from "../../interfaces/user-ops.interface";
+import { WithdrawProveOutput } from "../../state/thunks/withdrawThunk";
+
+/**
+ * A fully built + signed paymaster withdrawal, ready to relay to the bundler.
+ * The userOp is assembled in the prepare phase (`paymasterWithdrawThunk`), so
+ * the broadcaster only forwards it and awaits the receipt.
+ */
+export interface IGenericPaymasterWithdrawalPayload {
+  mode: "paymaster";
+  proof: WithdrawProveOutput;
+  poolAddress: Address;
+  isERC20: boolean;
+  paymasterAddress: `0x${string}`;
+  entryPointAddress: `0x${string}`;
+  bundlerUrl: string;
+  userOperation: SerializedUserOperation;
+}
+
+export interface PaymasterBroadcastResult {
+  userOpHash: Hash;
+  /** The mined bundle transaction hash from the userOp receipt. */
+  txHash: Hash;
+}
+
+export interface IPaymasterBroadcasterClient {
+  broadcast(
+    withdrawals: IGenericPaymasterWithdrawalPayload[],
+  ): Promise<PaymasterBroadcastResult[]>;
+}

--- a/packages/privacy-pools/src/state/state-manager.ts
+++ b/packages/privacy-pools/src/state/state-manager.ts
@@ -287,6 +287,8 @@ export const storeStateManager = (
       amount,
       recipient,
       delegation,
+      tailCalls,
+      tailCallsGasEstimate,
     }: IPaymasterWithdrawapOperationParams) => {
       const chainInfo = await getChainInfo();
       const store = await getChainStore(chainInfo);
@@ -308,6 +310,8 @@ export const storeStateManager = (
             recipient,
             paymasterConfig,
             delegation,
+            tailCalls,
+            tailCallsGasEstimate,
           }),
         ),
       );

--- a/packages/privacy-pools/src/state/state-manager.ts
+++ b/packages/privacy-pools/src/state/state-manager.ts
@@ -8,10 +8,12 @@ import { IDataService } from "../data/interfaces/data.service.interface";
 import { relayDataAbi } from "../data/abis/entrypoint.abi";
 import { Address } from "../interfaces/types.interface";
 import {
+  IChainsPaymastersConfig,
   IDepositOperationParams,
   IEntrypoint,
   IGetNotesParams,
   INote,
+  IPaymasterWithdrawapOperationParams,
   IRagequitAssetsOperationParams,
   IRagequitLabelsOperationParams,
   IStateManager,
@@ -37,7 +39,6 @@ import {
 } from "./selectors/pools.selector";
 import {
   entrypointInfoSelector,
-  userSecretsSelector,
 } from "./selectors/slices.selectors";
 import { buildDepositPayload, myDepositsCountSelector } from "./selectors/deposits.selector";
 import {
@@ -47,6 +48,7 @@ import {
 } from "./selectors/balance.selector";
 import { getNoteSelector } from "./selectors/notes.selector";
 import { PublicRootState, RootState, storeFactory } from "./store";
+import { paymasterWithdrawThunk } from "./thunks/paymasterWithdrawThunk";
 import { quoteThunk } from "./thunks/quoteThunk";
 import { ragequitThunk } from "./thunks/ragequitThunk";
 import { SyncAspThunkParams } from "./thunks/syncAspThunk";
@@ -62,6 +64,7 @@ export interface StoreFactoryParams extends SyncAspThunkParams {
   entrypoint: IEntrypoint;
   proverFactory: () => ReturnType<typeof Prover>;
   initialState?: () => Promise<Record<string, PublicRootState>>;
+  paymasterConfig?: IChainsPaymastersConfig;
 }
 
 const initializeSelectors = <const T extends Store>({
@@ -278,6 +281,36 @@ export const storeStateManager = (
         quoteData: { quote, relayerId },
         chainId: chainInfo.chainId,
       }];
+    },
+    getPaymasterWithdrawalPayloads: async ({
+      asset,
+      amount,
+      recipient,
+      delegation,
+    }: IPaymasterWithdrawapOperationParams) => {
+      const chainInfo = await getChainInfo();
+      const store = await getChainStore(chainInfo);
+      const paymasterConfig = params.paymasterConfig?.[Number(chainInfo.chainId)];
+
+      if (!paymasterConfig) {
+        throw new Error(`No paymaster config for chain ${chainInfo.chainId}`);
+      }
+
+      return unwrapResult(
+        await store.dispatch(
+          paymasterWithdrawThunk({
+            getNextNote: store.selectors.getNextNote,
+            proverFactory: params.proverFactory,
+            dataService: params.dataService,
+            secretManager,
+            asset,
+            amount,
+            recipient,
+            paymasterConfig,
+            delegation,
+          }),
+        ),
+      );
     },
     getRagequitPayloads: async ({
       assets = [],

--- a/packages/privacy-pools/src/state/thunks/paymasterWithdrawThunk.ts
+++ b/packages/privacy-pools/src/state/thunks/paymasterWithdrawThunk.ts
@@ -1,0 +1,229 @@
+/* eslint-disable max-lines */
+import { Prover } from "@fatsolutions/privacy-pools-core-circuits";
+import { createAsyncThunk, unwrapResult } from "@reduxjs/toolkit";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+
+import { ISecretManager } from "../../account/keys";
+import { E_ADDRESS } from "../../config";
+import { IDataService } from "../../data/interfaces/data.service.interface";
+import { Address } from "../../interfaces/types.interface";
+import { DelegationConfig, DelegatorAccount, UserOpGasLimits } from "../../interfaces/user-ops.interface";
+import { computeMinimumViableFee, reasonableGasUnits } from "../../paymaster/fee";
+import { encodeFeeData, encodePaymasterData, encodePrivacyPoolAdapterData } from "../../paymaster/adapter-data";
+import {
+  buildSignedUserOp,
+  createPaymasterBundlerClient,
+  estimateUserOperationGas,
+  getUserOperationGasPrice,
+} from "../../paymaster/utils";
+import { IPaymasterConfig } from "../../plugin/interfaces/protocol-params.interface";
+import { IGenericPaymasterWithdrawalPayload } from "../../relayer/interfaces/paymaster-client.interface";
+import { WithdrawalPayload } from "../../relayer/interfaces/relayer-client.interface";
+import { addressToHex } from "../../utils";
+import { calculateContext } from "../../utils/proof.util";
+import { getNoteSelector } from "../selectors/notes.selector";
+import { poolFromAssetSelector } from "../selectors/pools.selector";
+import { entrypointInfoSelector } from "../selectors/slices.selectors";
+import { RootState } from "../store";
+import { verifyRootsThunk } from "./verifyRootsThunk";
+import { WithdrawProveOutput, WithdrawThunkParams, withdrawThunk } from "./withdrawThunk";
+
+export interface PaymasterWithdrawThunkParams {
+  getNextNote: WithdrawThunkParams["getNextNote"];
+  proverFactory: () => ReturnType<typeof Prover>;
+  dataService: IDataService;
+  secretManager: ISecretManager;
+  asset: Address;
+  amount?: bigint;
+  recipient: Address;
+  paymasterConfig: IPaymasterConfig;
+  delegation?: DelegationConfig;
+}
+
+export const paymasterWithdrawThunk = createAsyncThunk<
+  IGenericPaymasterWithdrawalPayload[],
+  PaymasterWithdrawThunkParams,
+  { state: RootState }
+>(
+  "withdraw/executePaymasterWithdrawals",
+  async (
+    { getNextNote, proverFactory, dataService, secretManager, asset, amount, recipient, paymasterConfig, delegation },
+    { getState, dispatch },
+  ) => {
+    const state = getState();
+    const { chainId, entrypointAddress } = entrypointInfoSelector(state);
+
+    const poolInfo = poolFromAssetSelector(state, asset);
+
+    if (!poolInfo) throw new Error(`No pool found for asset ${asset}`);
+
+    const isERC20 = poolInfo.asset !== BigInt(E_ADDRESS);
+
+    // Resolve the note first: it fixes the withdrawn value and the deposit index
+    // used to derive a recoverable ephemeral sender.
+    const note = getNoteSelector(state, asset, amount ?? 0n);
+
+    if (!note) throw new Error("No note with sufficient balance for withdrawal");
+
+    const withdrawnValue = amount ?? note.balance;
+
+    if (withdrawnValue <= 0n) throw new Error("Withdrawal amount must be greater than zero");
+
+    const { bundlerUrl, entryPointAddress, paymasterAddress, poolsAccountsMap } = paymasterConfig;
+    const adapterAddress = poolsAccountsMap[addressToHex(poolInfo.address).toLowerCase()];
+
+    if (!adapterAddress) {
+      throw new Error(`No paymaster adapter configured for pool ${addressToHex(poolInfo.address)}`);
+    }
+
+    unwrapResult(await dispatch(verifyRootsThunk({ dataService })));
+
+    const bundlerClient = createPaymasterBundlerClient(bundlerUrl);
+    const {
+      standard: { maxFeePerGas, maxPriorityFeePerGas },
+    } = await getUserOperationGasPrice(bundlerClient);
+
+    const signer = await resolveSigner({
+      delegation,
+      secretManager,
+      chainId,
+      entrypointAddress,
+      depositIndex: note.deposit,
+      withdrawIndex: note.withdraw,
+    });
+
+    // The absolute fee (in the pool asset) the adapter forwards to the paymaster:
+    // the wei gas cost for native pools, priced into the token via the paymaster's
+    // own oracle for ERC20 pools. `feePaid >= paymaster.quoteWeiInToken(maxCost)`
+    // holds because both sides read the same oracle and we bound the gas at maxCost.
+    const feeFor = async (ethFee: bigint): Promise<bigint> => {
+      const fee = isERC20
+        ? await dataService.quoteWeiInToken(BigInt(paymasterAddress) as Address, poolInfo.asset, ethFee)
+        : ethFee;
+
+      if (fee > withdrawnValue) {
+        throw new Error("Withdrawal amount too small to cover the sponsored gas fee");
+      }
+
+      return fee;
+    };
+
+    const buildWithdrawal = (fee: bigint): WithdrawalPayload => ({
+      // The adapter is the withdrawal `processooor`: it calls pool.withdraw
+      // directly during paymaster validation and enforces `processooor == self`.
+      processooor: adapterAddress,
+      data: encodeFeeData({
+        recipient: addressToHex(recipient),
+        feeRecipient: paymasterAddress,
+        fee,
+      }),
+    });
+
+    const prove = (context: bigint): Promise<WithdrawProveOutput> =>
+      dispatch(
+        withdrawThunk({ getNextNote, proverFactory, asset, amount: withdrawnValue, recipient, context }),
+      ).then(unwrapResult);
+
+    // No execution phase: callGasLimit stays 0 (funds are released to the
+    // recipient during paymaster validation).
+    const withGas = (base: UserOpGasLimits): UserOpGasLimits => ({ ...base, callGasLimit: 0n });
+
+    const buildUserOp = async (gas: UserOpGasLimits) => {
+      const fee = await feeFor(computeMinimumViableFee(gas, maxFeePerGas));
+      const withdrawal = buildWithdrawal(fee);
+      const context = BigInt(calculateContext(withdrawal, poolInfo.scope));
+      const proof = await prove(context);
+      const paymasterData = encodePaymasterData(
+        adapterAddress,
+        encodePrivacyPoolAdapterData(withdrawal, proof),
+      );
+      const userOperation = await buildSignedUserOp({
+        signer,
+        chainId: Number(chainId),
+        paymasterAddress,
+        paymasterData,
+        gas,
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+        nonce: 0n,
+      });
+
+      return { proof, userOperation };
+    };
+
+    const baselineGas = withGas(reasonableGasUnits(isERC20));
+    let { proof, userOperation } = await buildUserOp(baselineGas);
+
+    // Refine gas against the bundler's simulation; re-prove once at the refined
+    // fee so the proof matches the tighter limits. Best-effort — on failure we
+    // keep the safe baseline.
+    const refinedGas = await refineGasWithBundler(bundlerClient, userOperation, entryPointAddress, baselineGas);
+
+    if (refinedGas !== baselineGas) {
+      ({ proof, userOperation } = await buildUserOp(withGas(refinedGas)));
+    }
+
+    return [
+      {
+        mode: "paymaster" as const,
+        proof,
+        poolAddress: poolInfo.address,
+        isERC20,
+        paymasterAddress,
+        entryPointAddress,
+        bundlerUrl,
+        userOperation,
+      },
+    ];
+  },
+);
+
+async function resolveSigner({
+  delegation,
+  secretManager,
+  chainId,
+  entrypointAddress,
+  depositIndex,
+  withdrawIndex,
+}: {
+  delegation?: DelegationConfig;
+  secretManager: ISecretManager;
+  chainId: bigint;
+  entrypointAddress: bigint;
+  depositIndex: number;
+  withdrawIndex: number;
+}): Promise<DelegatorAccount> {
+  if (delegation?.mode === "random") {
+    return privateKeyToAccount(generatePrivateKey());
+  }
+
+  return privateKeyToAccount(
+    await secretManager.deriveEphemeralSigner({ chainId, entrypointAddress, depositIndex, withdrawIndex }),
+  );
+}
+
+async function refineGasWithBundler(
+  bundlerClient: ReturnType<typeof createPaymasterBundlerClient>,
+  provisionalUserOp: Awaited<ReturnType<typeof buildSignedUserOp>>,
+  entryPointAddress: `0x${string}`,
+  baselineGas: UserOpGasLimits,
+): Promise<UserOpGasLimits> {
+  try {
+    const estimated = await estimateUserOperationGas(bundlerClient, provisionalUserOp, entryPointAddress);
+    const buffer = (x: bigint) => (x * 12n) / 10n;
+    const orBaseline = (e: bigint, b: bigint) => (e > 0n ? buffer(e) : b);
+
+    return {
+      callGasLimit: orBaseline(estimated.callGasLimit, baselineGas.callGasLimit),
+      verificationGasLimit: orBaseline(estimated.verificationGasLimit, baselineGas.verificationGasLimit),
+      preVerificationGas: orBaseline(estimated.preVerificationGas, baselineGas.preVerificationGas),
+      paymasterVerificationGasLimit: orBaseline(
+        estimated.paymasterVerificationGasLimit,
+        baselineGas.paymasterVerificationGasLimit,
+      ),
+      paymasterPostOpGasLimit: orBaseline(estimated.paymasterPostOpGasLimit, baselineGas.paymasterPostOpGasLimit),
+    };
+  } catch {
+    return baselineGas;
+  }
+}

--- a/packages/privacy-pools/src/state/thunks/paymasterWithdrawThunk.ts
+++ b/packages/privacy-pools/src/state/thunks/paymasterWithdrawThunk.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
 import { Prover } from "@fatsolutions/privacy-pools-core-circuits";
+import { TxData } from "@kohaku-eth/provider";
 import { createAsyncThunk, unwrapResult } from "@reduxjs/toolkit";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
@@ -8,7 +9,7 @@ import { E_ADDRESS } from "../../config";
 import { IDataService } from "../../data/interfaces/data.service.interface";
 import { Address } from "../../interfaces/types.interface";
 import { DelegationConfig, DelegatorAccount, UserOpGasLimits } from "../../interfaces/user-ops.interface";
-import { computeMinimumViableFee, reasonableGasUnits } from "../../paymaster/fee";
+import { computeMinimumViableFee, reasonableGasUnits, TAIL_CALLS_DEFAULT_GAS } from "../../paymaster/fee";
 import { encodeFeeData, encodePaymasterData, encodePrivacyPoolAdapterData } from "../../paymaster/adapter-data";
 import {
   buildSignedUserOp,
@@ -38,6 +39,15 @@ export interface PaymasterWithdrawThunkParams {
   recipient: Address;
   paymasterConfig: IPaymasterConfig;
   delegation?: DelegationConfig;
+  /**
+   * Optional execution-phase calls the ephemeral sender runs after the
+   * withdrawal. When present, the withdrawn funds (minus fee) are paid to the
+   * sender and these calls spend them atomically; `recipient` is ignored for the
+   * payout (it stays the sender, as the adapter requires for a non-zero
+   * callGasLimit).
+   */
+  tailCalls?: (sender: `0x${string}`) => Promise<TxData[]>;
+  tailCallsGasEstimate?: bigint;
 }
 
 export const paymasterWithdrawThunk = createAsyncThunk<
@@ -47,7 +57,19 @@ export const paymasterWithdrawThunk = createAsyncThunk<
 >(
   "withdraw/executePaymasterWithdrawals",
   async (
-    { getNextNote, proverFactory, dataService, secretManager, asset, amount, recipient, paymasterConfig, delegation },
+    {
+      getNextNote,
+      proverFactory,
+      dataService,
+      secretManager,
+      asset,
+      amount,
+      recipient,
+      paymasterConfig,
+      delegation,
+      tailCalls,
+      tailCallsGasEstimate,
+    },
     { getState, dispatch },
   ) => {
     const state = getState();
@@ -108,12 +130,19 @@ export const paymasterWithdrawThunk = createAsyncThunk<
       return fee;
     };
 
+    // With tail calls the adapter must pay the sender (it enforces
+    // `recipient == sender` whenever callGasLimit != 0), and the execution phase
+    // spends those funds; otherwise the withdrawal pays the user's recipient
+    // directly and there is no execution phase.
+    const payoutRecipient = tailCalls ? signer.address : addressToHex(recipient);
+    const executionGas = tailCalls ? (tailCallsGasEstimate ?? TAIL_CALLS_DEFAULT_GAS) : 0n;
+
     const buildWithdrawal = (fee: bigint): WithdrawalPayload => ({
       // The adapter is the withdrawal `processooor`: it calls pool.withdraw
       // directly during paymaster validation and enforces `processooor == self`.
       processooor: adapterAddress,
       data: encodeFeeData({
-        recipient: addressToHex(recipient),
+        recipient: payoutRecipient,
         feeRecipient: paymasterAddress,
         fee,
       }),
@@ -124,9 +153,8 @@ export const paymasterWithdrawThunk = createAsyncThunk<
         withdrawThunk({ getNextNote, proverFactory, asset, amount: withdrawnValue, recipient, context }),
       ).then(unwrapResult);
 
-    // No execution phase: callGasLimit stays 0 (funds are released to the
-    // recipient during paymaster validation).
-    const withGas = (base: UserOpGasLimits): UserOpGasLimits => ({ ...base, callGasLimit: 0n });
+    // callGasLimit sizes the execution phase (0 when there are no tail calls).
+    const withGas = (base: UserOpGasLimits): UserOpGasLimits => ({ ...base, callGasLimit: executionGas });
 
     const buildUserOp = async (gas: UserOpGasLimits) => {
       const fee = await feeFor(computeMinimumViableFee(gas, maxFeePerGas));
@@ -146,6 +174,7 @@ export const paymasterWithdrawThunk = createAsyncThunk<
         maxFeePerGas,
         maxPriorityFeePerGas,
         nonce: 0n,
+        tailCalls,
       });
 
       return { proof, userOperation };

--- a/packages/privacy-pools/src/utils/encoding.utils.ts
+++ b/packages/privacy-pools/src/utils/encoding.utils.ts
@@ -14,15 +14,23 @@ const definedOrThrow = <T>(i: T | undefined) => {
 };
 
 type WithdrawSignals = [bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint];
-export function encodeWithdrawalPayload(
-  withdraw: WithdrawalPayload,
-  proveOutput: WithdrawProveOutput,
-  scope: bigint
-) {
 
+export interface WithdrawProofStruct {
+  pA: [bigint, bigint];
+  pB: [[bigint, bigint], [bigint, bigint]];
+  pC: [bigint, bigint];
+  pubSignals: WithdrawSignals;
+}
+
+/**
+ * Maps a groth16 prove output into the on-chain `WithdrawProof` struct shape
+ * (`{ pA, pB, pC, pubSignals }`). Note the pB coordinates are swapped, as the
+ * Solidity verifier expects.
+ */
+export function toWithdrawProof(proveOutput: WithdrawProveOutput): WithdrawProofStruct {
   const {
     proof: { pi_a, pi_b, pi_c },
-    publicSignals
+    publicSignals,
   } = proveOutput;
 
   if (publicSignals.length !== 8) {
@@ -30,7 +38,6 @@ export function encodeWithdrawalPayload(
   }
 
   const pubSignals = publicSignals.map(BigInt) as WithdrawSignals;
-
   const pA = [pi_a[0], pi_a[1]].map(definedOrThrow).map(BigInt) as [bigint, bigint];
   const pB = [
     [definedOrThrow(pi_b[0])[1], definedOrThrow(pi_b[0])[0]].map(definedOrThrow).map(BigInt),
@@ -38,10 +45,18 @@ export function encodeWithdrawalPayload(
   ] as [[bigint, bigint], [bigint, bigint]];
   const pC = [pi_c[0], pi_c[1]].map(definedOrThrow).map(BigInt) as [bigint, bigint];
 
+  return { pA, pB, pC, pubSignals };
+}
+
+export function encodeWithdrawalPayload(
+  withdraw: WithdrawalPayload,
+  proveOutput: WithdrawProveOutput,
+  scope: bigint
+) {
   return encodeFunctionData({
     abi: entrypointAbi,
     functionName: "relay",
-    args: [withdraw, { pubSignals, pA, pB, pC }, scope]
+    args: [withdraw, toWithdrawProof(proveOutput), scope]
   });
 
 }

--- a/packages/privacy-pools/src/v1/interfaces.ts
+++ b/packages/privacy-pools/src/v1/interfaces.ts
@@ -1,6 +1,6 @@
 import { Broadcaster } from "@kohaku-eth/plugins/broadcaster";
 import { AssetAmount, ERC20AssetId, PluginInstance } from "@kohaku-eth/plugins";
-import { IEntrypoint, INote, PPv1PrivateOperation, PPv1PublicOperation, PrivacyPoolsV1ProtocolParams } from '../plugin/interfaces/protocol-params.interface.js';
+import { IChainsPaymastersConfig, IEntrypoint, INote, PPv1PrivateOperation, PPv1PublicOperation, PrivacyPoolsV1ProtocolParams } from '../plugin/interfaces/protocol-params.interface.js';
 import { Address } from 'ox/Address';
 import { IAspService } from "../data/asp.interface.js";
 import { ISuccessfullRelayResponse } from "../relayer/interfaces/relayer-client.interface.js";
@@ -17,6 +17,7 @@ export interface PPv1PluginParameters extends PPv1BroadcasterParameters, PPv1Bas
     ipfsUrl?: string;
     aspServiceFactory?: () => IAspService
     initialState?: PrivacyPoolsV1ProtocolParams['initialState']
+    paymasterConfig?: IChainsPaymastersConfig;
 };
 export interface PPv1PluginWithMnemonicParameters extends PPv1PluginParameters {
     mnemonic: string;

--- a/packages/privacy-pools/tests/e2e/ethers/saga-reconstruction.test.ts
+++ b/packages/privacy-pools/tests/e2e/ethers/saga-reconstruction.test.ts
@@ -1,0 +1,69 @@
+import { Client, HttpStore } from '@saga-sync/client';
+import { createPublicClient, decodeEventLog, http, parseAbi, type PublicClient } from 'viem';
+import { beforeAll, describe, expect, inject, it } from 'vitest';
+
+import { computeMerkleTreeRoot } from '../../../src/utils/proof.util';
+import { getChainConfigSetup } from '../../constants';
+
+// Validates the core saga claim: the pool Merkle tree is fully reconstructable
+// from saga's published Deposited/Withdrawn events (ragequit inserts no leaf).
+// Pick a cutoff at saga's coverage, rebuild the tree from deposits+withdrawals in
+// (block, logIndex) order, and assert its root equals the pool's on-chain root at
+// that block. Reads mainnet directly (archive) — no anvil/deposit machinery.
+const SAGA_SYNC_URL = process['env']['SAGA_SYNC_URL'];
+const chainId = inject('chainId');
+
+const POOLS = [
+  { protocol: 'privacy-pools-1-eth', address: '0xF241d57C6DebAe225c0F2e6eA1529373C9A9C9fB' as const },
+  { protocol: 'privacy-pools-1-usdt', address: '0xe859C0bD25f260BaEE534Fb52e307D3b64D24572' as const },
+  { protocol: 'privacy-pools-1-usdc', address: '0xb419c2867aB3CBc78921660cB95150d95A94ce86' as const },
+];
+
+const eventAbi = parseAbi([
+  'event Deposited(address indexed _depositor, uint256 _commitment, uint256 _label, uint256 _value, uint256 _precommitment)',
+  'event Withdrawn(address indexed _processooor, uint256 _value, uint256 _spentNullifier, uint256 _newCommitment)',
+]);
+const poolAbi = parseAbi(['function currentRoot() view returns (uint256)']);
+
+describe.skipIf(chainId !== 1 || !SAGA_SYNC_URL)('saga reconstruction — tree root matches chain', () => {
+  let saga: Client;
+  let manifest: Awaited<ReturnType<Client['fetchManifest']>>;
+  let rpc: PublicClient;
+  let headBlock: bigint;
+
+  beforeAll(async () => {
+    saga = new Client({ source: new HttpStore(SAGA_SYNC_URL!) });
+    manifest = await saga.fetchManifest();
+    rpc = createPublicClient({ transport: http(getChainConfigSetup(1).rpcUrl) });
+    headBlock = await rpc.getBlockNumber();
+  });
+
+  it.each(POOLS)('rebuilds $protocol from deposits+withdrawals matching on-chain root', async ({ protocol, address }) => {
+    const sagaLast = manifest.lastCoveredBlock(protocol);
+
+    expect(sagaLast).not.toBeNull();
+
+    const cutoff = sagaLast! < headBlock ? sagaLast! : headBlock;
+
+    const leaves: { block: bigint; logIndex: bigint; commitment: bigint }[] = [];
+
+    for await (const ev of saga.streamEvents(protocol, { fromBlock: 0n, toBlock: cutoff + 1n })) {
+      try {
+        const decoded = decodeEventLog({ abi: eventAbi, topics: ev.topics as [`0x${string}`, ...`0x${string}`[]], data: ev.data });
+        const commitment = decoded.eventName === 'Deposited' ? decoded.args._commitment : decoded.args._newCommitment;
+
+        leaves.push({ block: BigInt(ev.blockNumber), logIndex: BigInt(ev.logIndex), commitment });
+      } catch {
+        // Ragequit or other non-leaf event — skip.
+      }
+    }
+
+    leaves.sort((a, b) => (a.block === b.block ? Number(a.logIndex - b.logIndex) : Number(a.block - b.block)));
+
+    const localRoot = computeMerkleTreeRoot(leaves.map((l) => l.commitment));
+    const onchainRoot = await rpc.readContract({ address, abi: poolAbi, functionName: 'currentRoot', blockNumber: cutoff });
+
+    expect(leaves.length).toBeGreaterThan(0);
+    expect(localRoot).toBe(onchainRoot);
+  }, 180_000);
+});

--- a/packages/privacy-pools/tests/e2e/ethers/withdraw-paymaster-broadcast.test.ts
+++ b/packages/privacy-pools/tests/e2e/ethers/withdraw-paymaster-broadcast.test.ts
@@ -1,0 +1,179 @@
+import { Prover } from '@fatsolutions/privacy-pools-core-circuits';
+import { AccountId } from '@kohaku-eth/plugins';
+import { startServers } from '@privacy-paymasters/sdk/bundler-server';
+import { Wallet } from 'ethers';
+import { parseEther, type Hex } from 'viem';
+import { afterAll, beforeAll, describe, expect, inject, it } from 'vitest';
+
+import { E_ADDRESS, PrivacyPoolsPaymasterConfigs } from '../../../src/config';
+import { DataService } from '../../../src/data/data.service';
+import { EthClient } from '../../../src/data/eth-client';
+import { PrivacyPoolsV1Protocol } from '../../../src/index';
+import { PrivacyPoolsBroadcaster } from '../../../src/plugin/broadcaster';
+import { IChainsPaymastersConfig } from '../../../src/plugin/interfaces/protocol-params.interface';
+import { getChainConfigSetup } from '../../constants';
+import { defineAnvil, type AnvilInstance, type AnvilPool } from '../../utils/anvil';
+import { ERC20Asset, InitialState, loadInitialState, unwrapBalance } from '../../utils/common';
+import { createMockHost } from '../../utils/mock-host';
+import { createSagaLogSource } from '../../utils/saga-log-source';
+import { TEST_ACCOUNTS } from '../../utils/test-accounts';
+import {
+  getProtocolWithState,
+  MOCK_IPFS_CID,
+  pushNewAspRoot,
+  sendTxAndWait,
+  setupMockAspForTest,
+  setupWallet,
+} from '../../utils/test-helpers';
+
+// alto bundler operator keys (funded on the fork below).
+const EXECUTOR_PK = '0x4a3a02862ddcb260ed52d40ef03f8e3d78fa3d174b0ef333afdf1ffb4a648cd5' as Hex;
+const UTILITY_PK = '0xdd4b2564c83ff7de602c39ffda1146055dc1814b07c083d7971722384f1f01a6' as Hex;
+
+const SAGA_SYNC_URL = process['env']['SAGA_SYNC_URL'] ?? 'https://saga.fatsolutions.xyz';
+const chainId = inject('chainId');
+
+// Fresh recipient (starts at 0 ETH) so the sponsored payout is unambiguous.
+const RECIPIENT = '0xfE0fe0Fe0fe0fe0fE0fe0fe0Fe0fE0Fe0fE0fe00';
+
+describe.skipIf(chainId !== 1)('PrivacyPools v1 paymaster broadcast (real bundler, real prover)', () => {
+  let anvil: AnvilInstance;
+  // One shared fork instance: the bundler, state hydration, and the test's
+  // deposit/withdrawal must all run on the SAME chain, or the userOp executes
+  // against a fork that never saw the deposit (UnknownStateRoot).
+  let pool: AnvilPool;
+  let latestState: InitialState;
+  let bundlerRpcUrl: string;
+  let stopBundler: () => Promise<void>;
+
+  const { entrypoint, postman, rpcUrl } = getChainConfigSetup(1);
+  const ENTRYPOINT_ADDRESS = entrypoint.address;
+  const PAYMASTER_ADDRESS = PrivacyPoolsPaymasterConfigs[1]!.paymasterAddress;
+
+  beforeAll(async () => {
+    anvil = await defineAnvil({ forkUrl: rpcUrl, chainId: 1 });
+    await anvil.start();
+
+    pool = anvil.pool(1);
+
+    // Fund the bundler's executor/utility EOAs so alto can submit bundles.
+    await pool.setBalance(new Wallet(EXECUTOR_PK).address, `0x${parseEther('100').toString(16)}`);
+    await pool.setBalance(new Wallet(UTILITY_PK).address, `0x${parseEther('100').toString(16)}`);
+
+    // Start alto pointed at this fork.
+    ({ bundlerRpcUrl, stop: stopBundler } = await startServers({
+      execRpcUrl: pool.rpcUrl,
+      entrypoint: PrivacyPoolsPaymasterConfigs[1]!.entryPointAddress,
+      executorPrivateKey: EXECUTOR_PK,
+      utilityPrivateKey: UTILITY_PK,
+      port: 8546,
+    }));
+
+    // Fast state hydration via saga (pool leaves) + RPC (entrypoint/tail).
+    const host = createMockHost({ rpcUrl: pool.rpcUrl });
+    const rpcLogs = new EthClient(host.provider);
+    const sagaLogs = await createSagaLogSource({
+      sourceUrl: SAGA_SYNC_URL,
+      chainId: 1,
+      headBlock: BigInt(await pool.getBlockNumber()),
+      fallback: (params) => rpcLogs.getLogs(params),
+    });
+
+    const { protocol } = await getProtocolWithState({
+      entrypoint,
+      initialState: () => loadInitialState(1),
+      host,
+      rpcUrl: pool.rpcUrl,
+      postman,
+      dataService: new DataService({ provider: host.provider, getLogs: sagaLogs }),
+    });
+
+    await protocol.sync();
+    latestState = protocol.dumpState();
+  }, 600000);
+
+  afterAll(async () => {
+    await stopBundler?.();
+    await anvil.stop();
+  });
+
+  it('[paymaster] broadcasts a native withdrawal through the bundler', { timeout: 300_000 }, async () => {
+    const alice = await setupWallet(pool, TEST_ACCOUNTS.alice.privateKey);
+    const provider = await pool.getProvider();
+    const host = createMockHost({ rpcUrl: pool.rpcUrl });
+    const nativeAsset = ERC20Asset(E_ADDRESS);
+
+    // Route sponsored withdrawals to our local alto bundler.
+    const paymasterConfig: IChainsPaymastersConfig = {
+      1: { ...PrivacyPoolsPaymasterConfigs[1]!, bundlerUrl: bundlerRpcUrl },
+    };
+
+    const mockAspService = await setupMockAspForTest(pool.rpcUrl, ENTRYPOINT_ADDRESS, postman);
+
+    const protocol = new PrivacyPoolsV1Protocol(host, {
+      entrypoint,
+      initialState: async () => latestState,
+      proverFactory: () => Prover(), // real proof — required for on-chain acceptance
+      aspServiceFactory: () => mockAspService,
+      relayersList: {},
+      paymasterConfig,
+    });
+
+    const broadcaster = new PrivacyPoolsBroadcaster({ host, broadcasterUrl: { default: 'http://unused' } });
+
+    const DEPOSIT_AMOUNT = parseEther('2');
+    const WITHDRAW_AMOUNT = parseEther('1');
+
+    // 1. Deposit.
+    const { txns: [shieldTx] } = await protocol.prepareShield({ asset: nativeAsset, amount: DEPOSIT_AMOUNT });
+
+    expect((await sendTxAndWait(alice, shieldTx))?.status).toBe(1);
+    await pool.mine(1);
+
+    // 2. Approve the note via the mock ASP.
+    const [note] = await protocol.notes([nativeAsset]);
+
+    mockAspService.addLabel(note.label);
+    await pushNewAspRoot(
+      pool.rpcUrl,
+      '0x' + ENTRYPOINT_ADDRESS.toString(16),
+      '0x' + BigInt(postman).toString(16),
+      { _root: mockAspService.getRoot(), _ipfsCID: MOCK_IPFS_CID },
+    );
+
+    const approvedBefore = unwrapBalance(await protocol.balance([nativeAsset]), nativeAsset).approved?.amount ?? 0n;
+
+    expect(approvedBefore).toBeGreaterThanOrEqual(WITHDRAW_AMOUNT);
+
+    // 3. Prepare the sponsored withdrawal (real gas price from alto, real proof).
+    const op = await protocol.prepareUnshield(
+      { asset: nativeAsset, amount: WITHDRAW_AMOUNT },
+      RECIPIENT as AccountId,
+      { mode: 'paymaster' },
+    );
+
+    if (op.mode !== 'paymaster') throw new Error('expected paymaster operation');
+
+    const recipientBefore = await provider.getBalance(RECIPIENT);
+    const paymasterBefore = await provider.getBalance(PAYMASTER_ADDRESS);
+
+    expect(recipientBefore).toBe(0n);
+
+    // 4. Broadcast for real through the bundler, then mine the bundle.
+    await broadcaster.broadcast(op);
+    await pool.mine(1);
+
+    // 5. Assert on-chain effects.
+    const recipientAfter = await provider.getBalance(RECIPIENT);
+    const paymasterAfter = await provider.getBalance(PAYMASTER_ADDRESS);
+    const approvedAfter = unwrapBalance(await protocol.balance([nativeAsset]), nativeAsset).approved?.amount ?? 0n;
+
+    // Recipient received the withdrawal minus the sponsored-gas fee.
+    expect(recipientAfter).toBeGreaterThan(0n);
+    expect(recipientAfter).toBeLessThan(WITHDRAW_AMOUNT);
+    // Paymaster collected the fee.
+    expect(paymasterAfter).toBeGreaterThan(paymasterBefore);
+    // The note was spent.
+    expect(approvedAfter).toBe(approvedBefore - WITHDRAW_AMOUNT);
+  });
+});

--- a/packages/privacy-pools/tests/e2e/ethers/withdraw-paymaster-tailcalls.test.ts
+++ b/packages/privacy-pools/tests/e2e/ethers/withdraw-paymaster-tailcalls.test.ts
@@ -1,0 +1,278 @@
+import { Prover } from '@fatsolutions/privacy-pools-core-circuits';
+import { AccountId } from '@kohaku-eth/plugins';
+import { startServers } from '@privacy-paymasters/sdk/bundler-server';
+import { Wallet } from 'ethers';
+import { createPublicClient, decodeFunctionData, encodeFunctionData, erc20Abi, http, parseEther, parseUnits, type Hex } from 'viem';
+import { afterAll, beforeAll, describe, expect, inject, it } from 'vitest';
+
+import { E_ADDRESS, PrivacyPoolsPaymasterConfigs } from '../../../src/config';
+import { SIMPLE_7702_EXECUTE_ABI } from '../../../src/data/abis/account.abi';
+import { DataService } from '../../../src/data/data.service';
+import { EthClient } from '../../../src/data/eth-client';
+import { PrivacyPoolsV1Protocol } from '../../../src/index';
+import { PrivacyPoolsBroadcaster } from '../../../src/plugin/broadcaster';
+import { IChainsPaymastersConfig } from '../../../src/plugin/interfaces/protocol-params.interface';
+import { addressToHex } from '../../../src/utils';
+import { getChainConfigSetup } from '../../constants';
+import { defineAnvil, type AnvilInstance, type AnvilPool } from '../../utils/anvil';
+import { ERC20Asset, InitialState, loadInitialState, unwrapBalance } from '../../utils/common';
+import { createMockHost } from '../../utils/mock-host';
+import { createSagaLogSource } from '../../utils/saga-log-source';
+import { TEST_ACCOUNTS } from '../../utils/test-accounts';
+import {
+  approveERC20,
+  fundAccountWithERC20,
+  getProtocolWithState,
+  MOCK_IPFS_CID,
+  pushNewAspRoot,
+  sendTxAndWait,
+  setupMockAspForTest,
+  setupWallet,
+} from '../../utils/test-helpers';
+
+const EXECUTOR_PK = '0x4a3a02862ddcb260ed52d40ef03f8e3d78fa3d174b0ef333afdf1ffb4a648cd5' as Hex;
+const UTILITY_PK = '0xdd4b2564c83ff7de602c39ffda1146055dc1814b07c083d7971722384f1f01a6' as Hex;
+
+const SAGA_SYNC_URL = process['env']['SAGA_SYNC_URL'] ?? 'https://saga.fatsolutions.xyz';
+const chainId = inject('chainId');
+
+// Fresh addresses (start empty) that only the tail calls pay. Lowercase so they
+// pass viem's checksum validation when used directly in a tail call's `to`/args.
+const FINAL_RECIPIENT = '0xfe0fe0fe0fe0fe0fe0fe0fe0fe0fe0fe0fe0fe01';
+const USDC = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+const TAIL_RECIPIENT_A = '0xaa00aa00aa00aa00aa00aa00aa00aa00aa00aa01';
+const TAIL_RECIPIENT_B = '0xbb00bb00bb00bb00bb00bb00bb00bb00bb00bb02';
+
+describe.skipIf(chainId !== 1)('PrivacyPools v1 paymaster tail calls (real bundler, real prover)', () => {
+  let anvil: AnvilInstance;
+  let pool: AnvilPool;
+  let latestState: InitialState;
+  let bundlerRpcUrl: string;
+  let stopBundler: () => Promise<void>;
+
+  const { entrypoint, postman, rpcUrl } = getChainConfigSetup(1);
+  const ENTRYPOINT_ADDRESS = entrypoint.address;
+
+  beforeAll(async () => {
+    anvil = await defineAnvil({ forkUrl: rpcUrl, chainId: 1 });
+    await anvil.start();
+
+    pool = anvil.pool(1);
+
+    await pool.setBalance(new Wallet(EXECUTOR_PK).address, `0x${parseEther('100').toString(16)}`);
+    await pool.setBalance(new Wallet(UTILITY_PK).address, `0x${parseEther('100').toString(16)}`);
+
+    ({ bundlerRpcUrl, stop: stopBundler } = await startServers({
+      execRpcUrl: pool.rpcUrl,
+      entrypoint: PrivacyPoolsPaymasterConfigs[1]!.entryPointAddress,
+      executorPrivateKey: EXECUTOR_PK,
+      utilityPrivateKey: UTILITY_PK,
+      port: 8546,
+    }));
+
+    const host = createMockHost({ rpcUrl: pool.rpcUrl });
+    const rpcLogs = new EthClient(host.provider);
+    const sagaLogs = await createSagaLogSource({
+      sourceUrl: SAGA_SYNC_URL,
+      chainId: 1,
+      headBlock: BigInt(await pool.getBlockNumber()),
+      fallback: (params) => rpcLogs.getLogs(params),
+    });
+
+    const { protocol } = await getProtocolWithState({
+      entrypoint,
+      initialState: () => loadInitialState(1),
+      host,
+      rpcUrl: pool.rpcUrl,
+      postman,
+      dataService: new DataService({ provider: host.provider, getLogs: sagaLogs }),
+    });
+
+    await protocol.sync();
+    latestState = protocol.dumpState();
+  }, 600000);
+
+  afterAll(async () => {
+    await stopBundler?.();
+    await anvil.stop();
+  });
+
+  it('[paymaster] pays the withdrawal to the sender and forwards it via a tail call', { timeout: 300_000 }, async () => {
+    const alice = await setupWallet(pool, TEST_ACCOUNTS.alice.privateKey);
+    const provider = await pool.getProvider();
+    const host = createMockHost({ rpcUrl: pool.rpcUrl });
+    const nativeAsset = ERC20Asset(E_ADDRESS);
+
+    const paymasterConfig: IChainsPaymastersConfig = {
+      1: { ...PrivacyPoolsPaymasterConfigs[1]!, bundlerUrl: bundlerRpcUrl },
+    };
+
+    const mockAspService = await setupMockAspForTest(pool.rpcUrl, ENTRYPOINT_ADDRESS, postman);
+
+    const protocol = new PrivacyPoolsV1Protocol(host, {
+      entrypoint,
+      initialState: async () => latestState,
+      proverFactory: () => Prover(),
+      aspServiceFactory: () => mockAspService,
+      relayersList: {},
+      paymasterConfig,
+    });
+
+    const broadcaster = new PrivacyPoolsBroadcaster({ host, broadcasterUrl: { default: 'http://unused' } });
+
+    const DEPOSIT_AMOUNT = parseEther('2');
+    const WITHDRAW_AMOUNT = parseEther('1');
+    const FORWARD_AMOUNT = parseEther('0.5'); // safely below WITHDRAW_AMOUNT - fee
+
+    // 1. Deposit.
+    const { txns: [shieldTx] } = await protocol.prepareShield({ asset: nativeAsset, amount: DEPOSIT_AMOUNT });
+
+    expect((await sendTxAndWait(alice, shieldTx))?.status).toBe(1);
+    await pool.mine(1);
+
+    // 2. Approve the note via the mock ASP.
+    const [note] = await protocol.notes([nativeAsset]);
+
+    mockAspService.addLabel(note.label);
+    await pushNewAspRoot(
+      pool.rpcUrl,
+      '0x' + ENTRYPOINT_ADDRESS.toString(16),
+      '0x' + BigInt(postman).toString(16),
+      { _root: mockAspService.getRoot(), _ipfsCID: MOCK_IPFS_CID },
+    );
+
+    const approvedBefore = unwrapBalance(await protocol.balance([nativeAsset]), nativeAsset).approved?.amount ?? 0n;
+
+    expect(approvedBefore).toBeGreaterThanOrEqual(WITHDRAW_AMOUNT);
+
+    // 3. Prepare a sponsored withdrawal with a forwarding tail call. The
+    //    withdrawal pays the ephemeral sender; the tail call then forwards part
+    //    of it to a fresh recipient.
+    const op = await protocol.prepareUnshield(
+      { asset: nativeAsset, amount: WITHDRAW_AMOUNT },
+      FINAL_RECIPIENT as AccountId,
+      {
+        mode: 'paymaster',
+        tailCalls: async () => [{ to: FINAL_RECIPIENT, value: FORWARD_AMOUNT, data: '0x' }],
+      },
+    );
+
+    if (op.mode !== 'paymaster') throw new Error('expected paymaster operation');
+
+    // The execution phase is populated (execute()), unlike the no-tail-call flow.
+    expect(op.withdrawal.userOperation.callData).not.toBe('0x');
+    // The sender is distinct from the final recipient (the adapter paid the sender).
+    expect(op.withdrawal.userOperation.sender.toLowerCase()).not.toBe(FINAL_RECIPIENT.toLowerCase());
+
+    const recipientBefore = await provider.getBalance(FINAL_RECIPIENT);
+
+    expect(recipientBefore).toBe(0n);
+
+    // 4. Broadcast + mine.
+    await broadcaster.broadcast(op);
+    await pool.mine(1);
+
+    // 5. The tail call delivered exactly FORWARD_AMOUNT to the fresh recipient,
+    //    and the note was spent.
+    const recipientAfter = await provider.getBalance(FINAL_RECIPIENT);
+    const approvedAfter = unwrapBalance(await protocol.balance([nativeAsset]), nativeAsset).approved?.amount ?? 0n;
+
+    expect(recipientAfter).toBe(FORWARD_AMOUNT);
+    expect(approvedAfter).toBe(approvedBefore - WITHDRAW_AMOUNT);
+  });
+
+  it('[paymaster] batches two ERC20 transfers as executeBatch tail calls', { timeout: 300_000 }, async () => {
+    const alice = await setupWallet(pool, TEST_ACCOUNTS.alice.privateKey);
+    const host = createMockHost({ rpcUrl: pool.rpcUrl });
+    const rpc = createPublicClient({ transport: http(pool.rpcUrl) });
+    const usdcAsset = ERC20Asset(USDC);
+
+    const paymasterConfig: IChainsPaymastersConfig = {
+      1: { ...PrivacyPoolsPaymasterConfigs[1]!, bundlerUrl: bundlerRpcUrl },
+    };
+
+    const mockAspService = await setupMockAspForTest(pool.rpcUrl, ENTRYPOINT_ADDRESS, postman);
+
+    const protocol = new PrivacyPoolsV1Protocol(host, {
+      entrypoint,
+      initialState: async () => latestState,
+      proverFactory: () => Prover(),
+      aspServiceFactory: () => mockAspService,
+      relayersList: {},
+      paymasterConfig,
+    });
+
+    const broadcaster = new PrivacyPoolsBroadcaster({ host, broadcasterUrl: { default: 'http://unused' } });
+
+    const DEPOSIT_AMOUNT = parseUnits('300', 6); // USDC, 6 decimals
+    const WITHDRAW_AMOUNT = parseUnits('200', 6);
+    const TRANSFER_A = parseUnits('50', 6);
+    const TRANSFER_B = parseUnits('40', 6);
+
+    const usdcBalance = (address: string) =>
+      rpc.readContract({ address: USDC, abi: erc20Abi, functionName: 'balanceOf', args: [address as `0x${string}`] });
+
+    // 1. Fund + approve + deposit USDC.
+    await fundAccountWithERC20(pool.rpcUrl, USDC, alice.address, DEPOSIT_AMOUNT);
+    expect((await approveERC20(alice, USDC, addressToHex(ENTRYPOINT_ADDRESS), DEPOSIT_AMOUNT))?.status).toBe(1);
+
+    const { txns: [shieldTx] } = await protocol.prepareShield({ asset: usdcAsset, amount: DEPOSIT_AMOUNT });
+
+    expect((await sendTxAndWait(alice, shieldTx))?.status).toBe(1);
+    await pool.mine(1);
+
+    // 2. Approve the note via the mock ASP.
+    const [note] = await protocol.notes([usdcAsset]);
+
+    mockAspService.addLabel(note.label);
+    await pushNewAspRoot(
+      pool.rpcUrl,
+      '0x' + ENTRYPOINT_ADDRESS.toString(16),
+      '0x' + BigInt(postman).toString(16),
+      { _root: mockAspService.getRoot(), _ipfsCID: MOCK_IPFS_CID },
+    );
+
+    const approvedBefore = unwrapBalance(await protocol.balance([usdcAsset]), usdcAsset).approved?.amount ?? 0n;
+
+    expect(approvedBefore).toBeGreaterThanOrEqual(WITHDRAW_AMOUNT);
+
+    // 3. Two ERC20 transfers as tail calls (spent from the sender, which the
+    //    adapter funded) — forces the executeBatch path.
+    const erc20Transfer = (to: string, amount: bigint) => ({
+      to: USDC,
+      value: 0n,
+      data: encodeFunctionData({ abi: erc20Abi, functionName: 'transfer', args: [to as `0x${string}`, amount] }),
+    });
+
+    const op = await protocol.prepareUnshield(
+      { asset: usdcAsset, amount: WITHDRAW_AMOUNT },
+      TAIL_RECIPIENT_A as AccountId,
+      {
+        mode: 'paymaster',
+        tailCalls: async () => [erc20Transfer(TAIL_RECIPIENT_A, TRANSFER_A), erc20Transfer(TAIL_RECIPIENT_B, TRANSFER_B)],
+      },
+    );
+
+    if (op.mode !== 'paymaster') throw new Error('expected paymaster operation');
+
+    // The execution phase is an executeBatch of the two transfers.
+    const decoded = decodeFunctionData({ abi: SIMPLE_7702_EXECUTE_ABI, data: op.withdrawal.userOperation.callData });
+
+    expect(decoded.functionName).toBe('executeBatch');
+    expect((decoded.args[0] as readonly unknown[]).length).toBe(2);
+
+    const [a0, b0] = await Promise.all([usdcBalance(TAIL_RECIPIENT_A), usdcBalance(TAIL_RECIPIENT_B)]);
+
+    // 4. Broadcast + mine.
+    await broadcaster.broadcast(op);
+    await pool.mine(1);
+
+    // 5. Both transfers landed for their exact amounts, and the note was spent.
+    const [a1, b1] = await Promise.all([usdcBalance(TAIL_RECIPIENT_A), usdcBalance(TAIL_RECIPIENT_B)]);
+    const approvedAfter = unwrapBalance(await protocol.balance([usdcAsset]), usdcAsset).approved?.amount ?? 0n;
+
+    expect(a1 - a0).toBe(TRANSFER_A);
+    expect(b1 - b0).toBe(TRANSFER_B);
+    expect(approvedAfter).toBe(approvedBefore - WITHDRAW_AMOUNT);
+  });
+});

--- a/packages/privacy-pools/tests/e2e/ethers/withdraw-paymaster.test.ts
+++ b/packages/privacy-pools/tests/e2e/ethers/withdraw-paymaster.test.ts
@@ -1,0 +1,204 @@
+import { afterAll, beforeAll, describe, expect, inject, it, vi } from 'vitest';
+
+import { AccountId } from '@kohaku-eth/plugins';
+import { decodeAbiParameters, getAddress, parseAbiParameters } from 'viem';
+
+import { PrivacyPoolsPaymasterConfigs } from '../../../src/config';
+import { DataService } from '../../../src/data/data.service';
+import { EthClient } from '../../../src/data/eth-client';
+import { PrivacyPoolsV1Protocol } from '../../../src/index';
+import { addressToHex } from '../../../src/utils';
+import { getChainConfigSetup } from '../../constants';
+import { defineAnvil, type AnvilInstance } from '../../utils/anvil';
+import { ERC20Asset, InitialState, loadInitialState, unwrapBalance } from '../../utils/common';
+import { createMockHost } from '../../utils/mock-host';
+import { mockProverFactory } from '../../utils/mock-prover';
+import { createSagaLogSource } from '../../utils/saga-log-source';
+import { TEST_ACCOUNTS } from '../../utils/test-accounts';
+import {
+  approveERC20,
+  fundAccountWithERC20,
+  getProtocolWithState,
+  MOCK_IPFS_CID,
+  pushNewAspRoot,
+  sendTxAndWait,
+  setupMockAspForTest,
+  setupWallet,
+} from '../../utils/test-helpers';
+
+// The bundler is external infra, so we stub only the two network calls the
+// prepare phase makes. The paymaster oracle (quoteWeiInToken) is NOT stubbed —
+// it runs against the real deployed paymaster on the fork.
+const MOCK_GAS_PRICE = { maxFeePerGas: 1_000_000_000n, maxPriorityFeePerGas: 1_000_000_000n };
+
+vi.mock('../../../src/paymaster/utils', async (importActual) => {
+  const actual = await importActual<typeof import('../../../src/paymaster/utils')>();
+
+  return {
+    ...actual,
+    getUserOperationGasPrice: vi.fn(async () => ({
+      slow: MOCK_GAS_PRICE,
+      standard: MOCK_GAS_PRICE,
+      fast: MOCK_GAS_PRICE,
+    })),
+    // Force the safe-baseline fallback (no live bundler to estimate against).
+    estimateUserOperationGas: vi.fn(async () => {
+      throw new Error('bundler estimation unavailable in test');
+    }),
+  };
+});
+
+// The paymaster + adapters are deployed on mainnet, so this suite forks the
+// mainnet RPC and only runs on the mainnet project. Pool state is hydrated from
+// saga-sync (fast); override SAGA_SYNC_URL to point elsewhere.
+const SAGA_SYNC_URL = process['env']['SAGA_SYNC_URL'] ?? 'https://saga.fatsolutions.xyz';
+const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
+const USDT_BALANCE_SLOT = 2;
+const USDT_POOL = 0xe859c0bd25f260baee534fb52e307d3b64d24572n;
+const USDT_ADAPTER = '0xFcA5515D05f372Db8E03Bcc6b1a96BF4aC006f33';
+const SIMPLE_7702_IMPL = '0xe6Cae83BdE06E4c305530e199D7217f42808555B';
+
+const chainId = inject('chainId');
+
+describe.skipIf(chainId !== 1)('PrivacyPools v1 paymaster unshield — real oracle (mainnet fork)', () => {
+  let anvil: AnvilInstance;
+  let latestState: InitialState;
+
+  const { entrypoint, postman, rpcUrl } = getChainConfigSetup(1);
+  const ENTRYPOINT_ADDRESS = entrypoint.address;
+  const ENTRYPOINT_HEX = addressToHex(ENTRYPOINT_ADDRESS);
+  const paymasterConfig = PrivacyPoolsPaymasterConfigs;
+  const PAYMASTER_ADDRESS = paymasterConfig[1]!.paymasterAddress;
+
+  beforeAll(async () => {
+    // Fork mainnet at its head (where the paymaster + adapters are deployed).
+    anvil = await defineAnvil({ forkUrl: rpcUrl, chainId: 1 });
+    await anvil.start();
+
+    const pool = anvil.pool(1);
+    const host = createMockHost({ rpcUrl: pool.rpcUrl });
+
+    // Optionally hydrate the heavy pool-event history from saga-sync; the
+    // entrypoint (not a saga stream) and any blocks past saga's coverage still
+    // come from the fork over RPC — result-identical, just far fewer round trips.
+    let dataService: DataService | undefined;
+
+    if (SAGA_SYNC_URL) {
+      const rpcLogs = new EthClient(host.provider);
+      const headBlock = BigInt(await pool.getBlockNumber());
+      const sagaLogs = await createSagaLogSource({
+        sourceUrl: SAGA_SYNC_URL,
+        chainId: 1,
+        headBlock,
+        fallback: (params) => rpcLogs.getLogs(params),
+      });
+
+      dataService = new DataService({ provider: host.provider, getLogs: sagaLogs });
+    }
+
+    const { protocol } = await getProtocolWithState({
+      entrypoint,
+      initialState: () => loadInitialState(1),
+      host,
+      rpcUrl: pool.rpcUrl,
+      postman,
+      ...(dataService ? { dataService } : {}),
+    });
+
+    // Reconciles the snapshot up to the fork head so a fresh deposit's Merkle
+    // state matches chain.
+    await protocol.sync();
+    latestState = protocol.dumpState();
+  }, 600000);
+
+  afterAll(async () => {
+    await anvil.stop();
+  });
+
+  it('[prepareUnshield/paymaster] prices the gas fee via the real paymaster oracle for a USDT withdrawal', { timeout: 300_000 }, async () => {
+    const pool = anvil.pool(20);
+    const alice = await setupWallet(pool, TEST_ACCOUNTS.alice.privateKey);
+    const host = createMockHost({ rpcUrl: pool.rpcUrl });
+    const dataService = new DataService({ provider: host.provider });
+
+    // Sanity: the real oracle answers on the fork (2.39 USDT ≈ 0.001 ETH).
+    const directQuote = await dataService.quoteWeiInToken(BigInt(PAYMASTER_ADDRESS), BigInt(USDT), 10n ** 15n);
+
+    expect(directQuote).toBeGreaterThan(0n);
+
+    const usdtAsset = ERC20Asset(USDT);
+    const mockAspService = await setupMockAspForTest(pool.rpcUrl, ENTRYPOINT_ADDRESS, postman);
+
+    const protocol = new PrivacyPoolsV1Protocol(host, {
+      entrypoint,
+      initialState: async () => latestState,
+      proverFactory: mockProverFactory,
+      aspServiceFactory: () => mockAspService,
+      relayersList: {},
+      paymasterConfig,
+    });
+
+    const DEPOSIT_AMOUNT = 1_000_000_000n; // 1,000 USDT (6 decimals)
+    const WITHDRAW_AMOUNT = 500_000_000n; // 500 USDT
+
+    // 1. Fund + deposit USDT.
+    await fundAccountWithERC20(pool.rpcUrl, USDT, alice.address, DEPOSIT_AMOUNT, USDT_BALANCE_SLOT);
+    const approval = await approveERC20(alice, USDT, ENTRYPOINT_HEX, DEPOSIT_AMOUNT);
+
+    expect(approval?.status).toBe(1);
+
+    const { txns: [shieldTx] } = await protocol.prepareShield({ asset: usdtAsset, amount: DEPOSIT_AMOUNT });
+    const depositReceipt = await sendTxAndWait(alice, shieldTx);
+
+    expect(depositReceipt?.status).toBe(1);
+    await pool.mine(1);
+
+    // 2. Approve the note via the mock ASP.
+    const [note] = await protocol.notes([usdtAsset]);
+
+    mockAspService.addLabel(note.label);
+    await pushNewAspRoot(
+      pool.rpcUrl,
+      ENTRYPOINT_HEX,
+      '0x' + BigInt(postman).toString(16),
+      { _root: mockAspService.getRoot(), _ipfsCID: MOCK_IPFS_CID },
+    );
+
+    const approved = unwrapBalance(await protocol.balance([usdtAsset]), usdtAsset).approved;
+
+    expect(approved?.amount).toBeGreaterThan(0n);
+
+    // 3. Prepare the paymaster withdrawal — this drives quoteWeiInToken on the
+    //    real paymaster through our thunk.
+    const op = await protocol.prepareUnshield(
+      { asset: usdtAsset, amount: WITHDRAW_AMOUNT },
+      alice.address as AccountId,
+      { mode: 'paymaster' },
+    );
+
+    if (op.mode !== 'paymaster') throw new Error('expected paymaster operation');
+
+    const { withdrawal } = op;
+
+    // 4. Assert the ERC20 path routed to the right adapter and built a signed op.
+    expect(withdrawal.isERC20).toBe(true);
+    expect(withdrawal.poolAddress).toBe(USDT_POOL);
+    expect(withdrawal.paymasterAddress).toBe(PAYMASTER_ADDRESS);
+
+    const { userOperation } = withdrawal;
+
+    expect(userOperation.callData).toBe('0x');
+    expect(userOperation.nonce).toBe('0x0');
+    expect(userOperation.paymaster).toBe(PAYMASTER_ADDRESS);
+    // paymasterData = abi.encode(PaymasterData{ adapter, adapterData }); the
+    // adapter must be the USDT pool's fee adapter.
+    const [decodedPaymasterData] = decodeAbiParameters(
+      parseAbiParameters('(address adapter, bytes adapterData)'),
+      userOperation.paymasterData!,
+    );
+
+    expect(getAddress(decodedPaymasterData.adapter)).toBe(getAddress(USDT_ADAPTER));
+    expect(userOperation.signature).toMatch(/^0x[0-9a-f]+$/i);
+    expect(userOperation.eip7702Auth?.address.toLowerCase()).toBe(SIMPLE_7702_IMPL.toLowerCase());
+  });
+});

--- a/packages/privacy-pools/tests/unit/paymaster-adapter-data.test.ts
+++ b/packages/privacy-pools/tests/unit/paymaster-adapter-data.test.ts
@@ -1,0 +1,58 @@
+import { decodeAbiParameters, getAddress, parseAbiParameters } from 'viem';
+import { describe, expect, it } from 'vitest';
+
+import { encodeFeeData, encodePaymasterData, encodePrivacyPoolAdapterData } from '../../src/paymaster/adapter-data';
+import { WithdrawalPayload } from '../../src/relayer/interfaces/relayer-client.interface';
+import { WithdrawProveOutput } from '../../src/state/thunks/withdrawThunk';
+import { mockedGroth16Proof } from '../utils/mock-prover';
+
+const ADAPTER = '0x00112233445566778899aabbccddeeff00112233' as const;
+const RECIPIENT = '0xcccccccccccccccccccccccccccccccccccccccc' as const;
+const PAYMASTER = '0xdddddddddddddddddddddddddddddddddddddddd' as const;
+
+const proof: WithdrawProveOutput = {
+  proof: mockedGroth16Proof,
+  publicSignals: ['1', '2', '3', '4', '5', '6', '7', '8'],
+  // mappedSignals is unused by the encoder.
+} as unknown as WithdrawProveOutput;
+
+describe('paymaster adapter-data encoding', () => {
+  it('encodeFeeData abi-encodes FeeData(recipient, feeRecipient, fee)', () => {
+    const encoded = encodeFeeData({ recipient: RECIPIENT, feeRecipient: PAYMASTER, fee: 250n });
+    const [decoded] = decodeAbiParameters(
+      parseAbiParameters('(address recipient, address feeRecipient, uint256 fee)'),
+      encoded,
+    );
+
+    expect(getAddress(decoded.recipient)).toBe(getAddress(RECIPIENT));
+    expect(getAddress(decoded.feeRecipient)).toBe(getAddress(PAYMASTER));
+    expect(decoded.fee).toBe(250n);
+  });
+
+  it('encodePaymasterData abi-encodes PaymasterData(adapter, adapterData)', () => {
+    const packed = encodePaymasterData(ADAPTER, '0xdeadbeef');
+    const [decoded] = decodeAbiParameters(parseAbiParameters('(address adapter, bytes adapterData)'), packed);
+
+    expect(getAddress(decoded.adapter)).toBe(getAddress(ADAPTER));
+    expect(decoded.adapterData).toBe('0xdeadbeef');
+  });
+
+  it('encodePrivacyPoolAdapterData abi-encodes AdapterData(withdrawal, proof)', () => {
+    const withdrawal: WithdrawalPayload = {
+      processooor: ADAPTER,
+      data: encodeFeeData({ recipient: RECIPIENT, feeRecipient: PAYMASTER, fee: 100n }),
+    };
+
+    const adapterData = encodePrivacyPoolAdapterData(withdrawal, proof);
+    const [decoded] = decodeAbiParameters(
+      parseAbiParameters(
+        '((address processooor, bytes data) withdrawal, (uint256[2] pA, uint256[2][2] pB, uint256[2] pC, uint256[8] pubSignals) proof)',
+      ),
+      adapterData,
+    );
+
+    expect(getAddress(decoded.withdrawal.processooor)).toBe(getAddress(ADAPTER));
+    expect(decoded.proof.pubSignals.length).toBe(8);
+    expect(decoded.proof.pubSignals[0]).toBe(1n);
+  });
+});

--- a/packages/privacy-pools/tests/unit/paymaster-fee.test.ts
+++ b/packages/privacy-pools/tests/unit/paymaster-fee.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeMinimumViableFee, reasonableGasUnits } from '../../src/paymaster/fee';
+
+describe('paymaster fee math', () => {
+  describe('reasonableGasUnits', () => {
+    it('keeps callGasLimit non-zero in the baseline (the thunk forces it to 0)', () => {
+      const gas = reasonableGasUnits(false);
+
+      expect(gas.callGasLimit).toBe(300_000n);
+      expect(gas.paymasterVerificationGasLimit).toBe(1_200_000n);
+    });
+
+    it('adds the ERC20 transfer cost to paymaster validation, not callGasLimit', () => {
+      const eth = reasonableGasUnits(false);
+      const erc20 = reasonableGasUnits(true);
+
+      expect(erc20.paymasterVerificationGasLimit).toBe(eth.paymasterVerificationGasLimit + 100_000n);
+      expect(erc20.callGasLimit).toBe(eth.callGasLimit);
+    });
+  });
+
+  describe('computeMinimumViableFee', () => {
+    it('sums every gas field, prices at maxFeePerGas, and applies the 1.2x buffer', () => {
+      const gas = reasonableGasUnits(false);
+      const maxFeePerGas = 1_000_000_000n; // 1 gwei
+
+      const totalGas =
+        gas.verificationGasLimit +
+        gas.callGasLimit +
+        gas.paymasterVerificationGasLimit +
+        gas.preVerificationGas +
+        gas.paymasterPostOpGasLimit;
+
+      const expected = (totalGas * maxFeePerGas * 12n) / 10n;
+
+      expect(computeMinimumViableFee(gas, maxFeePerGas)).toBe(expected);
+    });
+
+    it('scales linearly with maxFeePerGas', () => {
+      const gas = reasonableGasUnits(true);
+
+      expect(computeMinimumViableFee(gas, 2n)).toBe(computeMinimumViableFee(gas, 1n) * 2n);
+    });
+  });
+});

--- a/packages/privacy-pools/tests/unit/paymaster-keys.test.ts
+++ b/packages/privacy-pools/tests/unit/paymaster-keys.test.ts
@@ -1,0 +1,54 @@
+import { privateKeyToAccount } from 'viem/accounts';
+import { describe, expect, it } from 'vitest';
+
+import { SecretManager } from '../../src/account/keys';
+import { createMockHost } from '../utils/mock-host';
+
+const ENTRYPOINT = 0x34a2068192b1297f2a7f85d7d8cde66f8f0921cbn;
+const CHAIN_ID = 11155111n;
+
+const makeManager = () => SecretManager({ host: createMockHost(), accountIndex: 0 });
+
+describe('SecretManager.deriveEphemeralSigner', () => {
+  it('derives a valid 32-byte secp256k1 private key', async () => {
+    const key = await makeManager().deriveEphemeralSigner({
+      chainId: CHAIN_ID,
+      entrypointAddress: ENTRYPOINT,
+      depositIndex: 0,
+      withdrawIndex: 0,
+    });
+
+    expect(key).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(() => privateKeyToAccount(key)).not.toThrow();
+  });
+
+  it('is deterministic for the same (chainId, entrypoint, depositIndex, withdrawIndex)', async () => {
+    const params = { chainId: CHAIN_ID, entrypointAddress: ENTRYPOINT, depositIndex: 3, withdrawIndex: 1 };
+    const a = await makeManager().deriveEphemeralSigner(params);
+    const b = await makeManager().deriveEphemeralSigner(params);
+
+    expect(a).toBe(b);
+  });
+
+  it('yields distinct keys per deposit index and per chain', async () => {
+    const manager = makeManager();
+    const base = { chainId: CHAIN_ID, entrypointAddress: ENTRYPOINT, depositIndex: 0, withdrawIndex: 0 };
+
+    const byDeposit = await manager.deriveEphemeralSigner({ ...base, depositIndex: 1 });
+    const byChain = await manager.deriveEphemeralSigner({ ...base, chainId: 1n });
+    const original = await manager.deriveEphemeralSigner(base);
+
+    expect(byDeposit).not.toBe(original);
+    expect(byChain).not.toBe(original);
+  });
+
+  it('yields a distinct key per withdraw index (partial withdrawals reuse a deposit)', async () => {
+    const manager = makeManager();
+    const base = { chainId: CHAIN_ID, entrypointAddress: ENTRYPOINT, depositIndex: 2, withdrawIndex: 0 };
+
+    const firstWithdrawal = await manager.deriveEphemeralSigner(base);
+    const secondWithdrawal = await manager.deriveEphemeralSigner({ ...base, withdrawIndex: 1 });
+
+    expect(secondWithdrawal).not.toBe(firstWithdrawal);
+  });
+});

--- a/packages/privacy-pools/tests/utils/saga-log-source.ts
+++ b/packages/privacy-pools/tests/utils/saga-log-source.ts
@@ -1,0 +1,130 @@
+import { Client, HttpStore, type CanonicalEvent } from '@saga-sync/client';
+import type { TxLog } from '@kohaku-eth/provider';
+import { decodeEventLog, encodeAbiParameters, parseAbi, toEventSelector, toHex } from 'viem';
+
+import type { GetLogsParams } from '../../src/data/eth-client';
+
+type LogsFn = (params: GetLogsParams) => Promise<TxLog[]>;
+
+export interface SagaLogSourceParams {
+  /** Base URL of the saga-sync manifest/CDN (HttpStore source). */
+  sourceUrl: string;
+  chainId: number;
+  /**
+   * The fork's pinned block number. saga tracks live, so its head can run past a
+   * pinned fork — every result (saga stream and RPC tail) is truncated to this
+   * block so hydrated state can never diverge from the fork's chain.
+   */
+  headBlock: bigint;
+  /** RPC fallback for addresses not published by saga (e.g. the entrypoint) and for the tail past saga coverage. */
+  fallback: LogsFn;
+  /** Optional Ed25519 public key to verify the manifest signature. */
+  publicKey?: string;
+}
+
+// saga publishes Deposited/Withdrawn/Ragequit but not LeafInserted — yet the pool
+// Merkle tree is built solely from LeafInserted. Every deposit and every
+// withdrawal inserts exactly one leaf (ragequit inserts none): the leaf is the
+// deposit's `_commitment` / the withdrawal's `_newCommitment`, in (block, logIndex)
+// order. So we reconstruct LeafInserted from the published events and hand the
+// existing sync a complete, correctly-ordered leaf stream.
+const leafAbi = parseAbi([
+  'event Deposited(address indexed _depositor, uint256 _commitment, uint256 _label, uint256 _value, uint256 _precommitment)',
+  'event Withdrawn(address indexed _processooor, uint256 _value, uint256 _spentNullifier, uint256 _newCommitment)',
+]);
+const LEAF_INSERTED_TOPIC = toEventSelector('event LeafInserted(uint256 _index, uint256 _leaf, uint256 _root)');
+
+const toTxLog = (ev: CanonicalEvent): TxLog => ({
+  address: ev.contractAddress,
+  data: ev.data,
+  topics: ev.topics,
+  blockNumber: BigInt(ev.blockNumber),
+});
+
+// The leaf commitment inserted by an event, or null if it inserts none (ragequit).
+function insertedLeaf(ev: CanonicalEvent): bigint | null {
+  try {
+    const decoded = decodeEventLog({ abi: leafAbi, topics: ev.topics as [`0x${string}`, ...`0x${string}`[]], data: ev.data });
+
+    if (decoded.eventName === 'Deposited') return decoded.args._commitment;
+
+    if (decoded.eventName === 'Withdrawn') return decoded.args._newCommitment;
+  } catch {
+    // Not a Deposited/Withdrawn event (e.g. Ragequit) — no leaf.
+  }
+
+  return null;
+}
+
+function synthLeafInsertedLog(pool: string, index: bigint, leaf: bigint, blockNumber: bigint): TxLog {
+  return {
+    address: pool,
+    topics: [LEAF_INSERTED_TOPIC],
+    // LeafInserted(uint256 _index, uint256 _leaf, uint256 _root); _root is unused by tree building.
+    data: encodeAbiParameters(
+      [{ type: 'uint256' }, { type: 'uint256' }, { type: 'uint256' }],
+      [index, leaf, 0n],
+    ),
+    blockNumber,
+  };
+}
+
+export async function createSagaLogSource({
+  sourceUrl,
+  chainId,
+  headBlock,
+  fallback,
+  publicKey,
+}: SagaLogSourceParams): Promise<LogsFn> {
+  const client = new Client({ source: new HttpStore(sourceUrl), publicKey });
+  const manifest = await client.fetchManifest();
+  const chainIdHex = toHex(chainId);
+
+  return async (params: GetLogsParams): Promise<TxLog[]> => {
+    const address = params.address as `0x${string}`;
+
+    let protocolId: string;
+
+    try {
+      protocolId = await client.resolveProtocolId({ address, chainId: chainIdHex });
+    } catch {
+      // Not published by saga (e.g. the entrypoint) — serve from RPC. The fork is
+      // authoritative and can't return past its own head, so it isn't clamped.
+      return fallback(params);
+    }
+
+    const sagaLast = manifest.lastCoveredBlock(protocolId);
+
+    if (sagaLast === null) return fallback(params);
+
+    // saga tracks live: never read past its coverage nor past the fork's pinned
+    // head (guards against saga's producer advancing beyond the fork).
+    const sagaCap = sagaLast < headBlock ? sagaLast : headBlock;
+    const reqTo = params.toBlock;
+    const sagaTo = reqTo !== undefined && reqTo < sagaCap ? reqTo : sagaCap;
+
+    // Reconstruct the full pool history (leaf indices are global, so always
+    // stream from the start — the sync merges by index, so this is idempotent).
+    const logs: TxLog[] = [];
+    let leafIndex = 1n; // on-chain LeafInserted is 1-based.
+
+    for await (const ev of client.streamEvents(protocolId, { fromBlock: 0n, toBlock: sagaTo + 1n })) {
+      logs.push(toTxLog(ev));
+
+      const leaf = insertedLeaf(ev);
+
+      if (leaf !== null) {
+        logs.push(synthLeafInsertedLog(address, leafIndex, leaf, BigInt(ev.blockNumber)));
+        leafIndex += 1n;
+      }
+    }
+
+    // saga's head is behind the request/fork — sync the (sagaLast, …] tail over
+    // RPC, which carries the real (correctly-indexed) LeafInserted events.
+    if (reqTo === undefined || reqTo > sagaLast) {
+      logs.push(...(await fallback({ ...params, fromBlock: sagaLast + 1n })));
+    }
+
+    return logs;
+  };
+}

--- a/packages/privacy-pools/tests/utils/test-helpers.ts
+++ b/packages/privacy-pools/tests/utils/test-helpers.ts
@@ -2,6 +2,7 @@ import { ERC20AssetId, Host } from '@kohaku-eth/plugins';
 import { AbiCoder, CallExceptionError, Contract, ContractTransactionResponse, getAddress, JsonRpcProvider, keccak256, SigningKey, toBeHex, Wallet } from "ethers";
 
 import { PrivacyPoolsV1Protocol } from '../../src';
+import { IDataService } from '../../src/data/interfaces/data.service.interface';
 import { IEntrypoint } from '../../src/plugin/interfaces/protocol-params.interface';
 import { type AnvilPool } from './anvil';
 import { InitialState } from './common';
@@ -218,6 +219,7 @@ interface SimplifiedProtocolParams {
   aspServiceFactory?: () => IMockAspService;
   rpcUrl: string;
   postman: string;
+  dataService?: IDataService;
 }
 export const getProtocolWithState = async ({
   entrypoint,
@@ -226,6 +228,7 @@ export const getProtocolWithState = async ({
   aspServiceFactory = createMockAspService,
   rpcUrl,
   postman,
+  dataService,
 }: SimplifiedProtocolParams) => {
   const aspService = aspServiceFactory();
 
@@ -242,6 +245,7 @@ export const getProtocolWithState = async ({
     aspServiceFactory: () => aspService,
     initialState,
     entrypoint,
+    ...(dataService ? { dataService } : {}),
   });
 
   return { aspService, protocol };
@@ -262,6 +266,7 @@ export async function setupMockAspForTest(
     "0x" + BigInt(postman).toString(16),
     { _root: mockAspService.getRoot(), _ipfsCID: MOCK_IPFS_CID }
   );
+
   return mockAspService;
 }
 

--- a/packages/privacy-pools/vitest.config.ts
+++ b/packages/privacy-pools/vitest.config.ts
@@ -11,6 +11,8 @@ const E2E_SUITES = [
   { suiteName: 'shield',          include: ['tests/e2e/**/shield.test.ts'],               timeout: 600_000 },
   { suiteName: 'withdraw-mocked', include: ['tests/e2e/**/withdraw.test.ts'],             timeout: 600_000 },
   { suiteName: 'withdraw-live',   include: ['tests/e2e/**/withdraw-real-prover.test.ts'], timeout: 600_000 },
+  { suiteName: 'withdraw-paymaster', include: ['tests/e2e/**/withdraw-paymaster.test.ts'], timeout: 600_000 },
+  { suiteName: 'saga-reconstruction', include: ['tests/e2e/**/saga-reconstruction.test.ts'], timeout: 300_000 },
   { suiteName: 'ragequit',        include: ['tests/e2e/**/ragequit.test.ts'],             timeout: 600_000 },
   { suiteName: 'sync',            include: ['tests/sync.test.ts'],                        timeout: 1_200_000 },
   { suiteName: 'asp-integration', include: ['tests/e2e/asp-services.test.ts'],            timeout: 60_000 },

--- a/packages/privacy-pools/vitest.config.ts
+++ b/packages/privacy-pools/vitest.config.ts
@@ -14,6 +14,7 @@ const E2E_SUITES = [
   { suiteName: 'withdraw-paymaster', include: ['tests/e2e/**/withdraw-paymaster.test.ts'], timeout: 600_000 },
   { suiteName: 'saga-reconstruction', include: ['tests/e2e/**/saga-reconstruction.test.ts'], timeout: 300_000 },
   { suiteName: 'withdraw-paymaster-broadcast', include: ['tests/e2e/**/withdraw-paymaster-broadcast.test.ts'], timeout: 600_000 },
+  { suiteName: 'withdraw-paymaster-tailcalls', include: ['tests/e2e/**/withdraw-paymaster-tailcalls.test.ts'], timeout: 600_000 },
   { suiteName: 'ragequit',        include: ['tests/e2e/**/ragequit.test.ts'],             timeout: 600_000 },
   { suiteName: 'sync',            include: ['tests/sync.test.ts'],                        timeout: 1_200_000 },
   { suiteName: 'asp-integration', include: ['tests/e2e/asp-services.test.ts'],            timeout: 60_000 },

--- a/packages/privacy-pools/vitest.config.ts
+++ b/packages/privacy-pools/vitest.config.ts
@@ -13,6 +13,7 @@ const E2E_SUITES = [
   { suiteName: 'withdraw-live',   include: ['tests/e2e/**/withdraw-real-prover.test.ts'], timeout: 600_000 },
   { suiteName: 'withdraw-paymaster', include: ['tests/e2e/**/withdraw-paymaster.test.ts'], timeout: 600_000 },
   { suiteName: 'saga-reconstruction', include: ['tests/e2e/**/saga-reconstruction.test.ts'], timeout: 300_000 },
+  { suiteName: 'withdraw-paymaster-broadcast', include: ['tests/e2e/**/withdraw-paymaster-broadcast.test.ts'], timeout: 600_000 },
   { suiteName: 'ragequit',        include: ['tests/e2e/**/ragequit.test.ts'],             timeout: 600_000 },
   { suiteName: 'sync',            include: ['tests/sync.test.ts'],                        timeout: 1_200_000 },
   { suiteName: 'asp-integration', include: ['tests/e2e/asp-services.test.ts'],            timeout: 60_000 },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,12 @@ importers:
         specifier: ^2.51.3
         version: 2.54.1(typescript@5.9.3)(zod@4.4.3)
     devDependencies:
+      '@privacy-paymasters/sdk':
+        specifier: 0.0.5
+        version: 0.0.5(typescript@5.9.3)(zod@4.4.3)
+      '@saga-sync/client':
+        specifier: ^0.1.4
+        version: 0.1.4
       '@types/node':
         specifier: ^24.1.0
         version: 24.13.2
@@ -2897,6 +2903,13 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@saga-sync/client@0.1.4':
+    resolution: {integrity: sha512-q/5rxQOGB2ShYNxsQggfd6KGZ4BAF2z4wSUdWmiRjN/8CXStbyVYgjupdCLbZ8jbtOdvKKEu1dhZDO7/o5gCEg==}
+    hasBin: true
+
+  '@saga-sync/core@0.1.4':
+    resolution: {integrity: sha512-eGO87WP57D4CulvLUHfrhj0SpQEYC6UX8rBowkai0UG8dz3X/uHfOMu7TVuIvKdvjhWOaKxeYpwecx2G+k1ntA==}
+
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
 
@@ -4804,6 +4817,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -6644,6 +6658,7 @@ packages:
   prom-client@14.2.0:
     resolution: {integrity: sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==}
     engines: {node: '>=10'}
+    deprecated: prom-client has been replaced by @prometheus-io/client
 
   prool@0.0.24:
     resolution: {integrity: sha512-L0EGUF5vK1XAQtceaiwfGxf0LGeJwurUizzc3i6JESsUyMROzGxTSMSBiajF8AoQaDYWIX2s1m00sC36CATrvQ==}
@@ -10623,6 +10638,15 @@ snapshots:
     optional: true
 
   '@rtsao/scc@1.1.0': {}
+
+  '@saga-sync/client@0.1.4':
+    dependencies:
+      '@saga-sync/core': 0.1.4
+
+  '@saga-sync/core@0.1.4':
+    dependencies:
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 2.2.0
 
   '@scure/base@1.2.6': {}
 


### PR DESCRIPTION
# Privacy Pools — Paymaster-Sponsored Withdrawals (with Tail Calls)

## What it does

Adds a gas-sponsored withdrawal path to Privacy Pools, alongside the existing relayer flow. The withdrawal is executed as an ERC-4337 userOp from an ephemeral EOA delegated to the user's Simple7702 account; the withdrawal proof rides in `paymasterData` and is executed on-chain by the deployed `PrivacyPoolsFeeAdapter` during paymaster validation. The on-chain paymaster fee is priced via the paymaster oracle, so users pay the withdrawn amount minus fee — no gas of their own.

## Key features

- `prepareUnshield(asset, to, { mode: 'paymaster', tailCalls })` — the new entry point; a `bundler`-mode broadcaster relays instead of the relayer
- **Tail calls (tornado-cash style)**: pass `tailCalls` to run arbitrary calls (via 7702 `execute`/`executeBatch`) in the userOp's execution phase, atomically with the withdrawal — e.g. a native withdrawal forwarded to another address, or an ERC20 withdrawal batching two token transfers. `callGasLimit` is sized accordingly; the adapter already supports it (recipient == sender check)
- Ephemeral recoverable signer derived per (deposit, withdraw) pair — no long-lived key per user

## Implementation surface

- New paymaster module: bundler client, Simple7702 userOp builder, gas/fee math, and `PaymasterData`/`AdapterData`/`FeeData` encoders (replicated locally — the shipped library has **no runtime dependency** on the paymaster SDK)
- `paymasterWithdrawThunk`: oracle-priced absolute fee bound into the proof context + a bundler gas-refinement loop
- State-manager/plugin wiring, per-chain paymaster config, injectable `dataService`/`getLogs` seams

## Testing

- Unit tests for fee math, data encoders, signer derivation
- Level A e2e: real deployed paymaster/oracle, USDT withdrawal on a mainnet fork (bundler calls stubbed)
- Level B e2e: full real broadcast — real ZK proof, local alto bundler, actual on-chain tx; asserts recipient payout (withdrawal − fee), paymaster fee collection, and note spend. Also covers the tail-call paths (native via `execute`, USDC via `executeBatch`)
- E2e fixtures hydrated from `@saga-sync/client` (pool leaves reconstructed from the Deposited/Withdrawn stream) — fast instead of `eth_getLogs` crawling — with a reconstruction test proving the rebuilt Merkle roots match on-chain at the cutoff block. Both new deps are test-only

## Risk notes for reviewers

- Atomicity relies on the adapter's existing `recipient == sender` / `callGasLimit` behavior — no contract changes in this PR
- Single-note withdrawals only; multi-deposit consolidation is out of scope
- Mainnet-fork e2e depends on external services (saga-sync, deployed paymaster) — CI should treat Level B as an integration job
